### PR TITLE
hotfix(v3.5.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "resolume-arena",
 	"main": "dist/index.js",
-	"version": "3.5.0",
+	"version": "3.5.1",
 	"description": "Resolume Arena 6 & 7 module for companion",
 	"api_version": "1.0.0",
 	"keywords": [

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -6,6 +6,7 @@ import {getCompositionActions} from './actions/composition/compositionActions';
 import {getDeckActions} from './actions/deck/deckActions';
 import {getLayerActions} from './actions/layer/layerActions';
 import {getLayerGroupActions} from './actions/layer-group/layerGroupActions';
+import {getCustomActions} from './actions/custom/customActions';
 
 export function getActions(resolumeArenaModuleInstance: ResolumeArenaModuleInstance): CompanionActionDefinitions {
 	return {
@@ -15,5 +16,6 @@ export function getActions(resolumeArenaModuleInstance: ResolumeArenaModuleInsta
 		...getDeckActions(resolumeArenaModuleInstance),
 		...getLayerActions(resolumeArenaModuleInstance),
 		...getLayerGroupActions(resolumeArenaModuleInstance),
+		...getCustomActions(resolumeArenaModuleInstance),
 	};
 }


### PR DESCRIPTION
fix custom OSC action that was lost in regression when refactoring the actions to files
<img width="225" alt="image" src="https://github.com/bitfocus/companion-module-resolume-arena/assets/10220112/185ac592-43e6-4d74-a58e-a4caa0830d4b">
