### PR TITLE
feat: clip name variable by fixed grid position (#151)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,34 @@ These feedbacks require the OSC Listener to be enabled.
 
 ---
 
+### Available Variables (REST API)
+These variables require the REST API to be configured and are updated in real-time via the WebSocket connection.
+
+#### Clip selection
+* `selectedClip` — JSON object with `layer`, `column`, and `clipName` of the currently selected clip
+* `selectedClipLayer` — layer number of the selected clip
+* `selectedClipColumn` — column number of the selected clip
+* `selectedClipName` — name of the selected clip
+
+#### Clip preview
+* `previewedClip` — JSON object with `layer`, `column`, and `clipName` of the currently previewed clip
+* `previewedClipLayer` — layer number of the previewed clip
+* `previewedClipColumn` — column number of the previewed clip
+* `previewedClipName` — name of the previewed clip
+
+#### Clip name by grid position
+Variables for the name of the clip at a fixed layer/column coordinate. These are registered automatically based on your composition size and update live as clip names change in Resolume.
+
+* `clip_name_l{layer}_c{column}` — name of the clip at the given grid position (e.g. `clip_name_l1_c3` for layer 1, column 3)
+
+Note: these variables do not update when clips are drag-swapped inside Resolume (Resolume API limitation).
+
+#### Columns
+* `selectedColumn` — column number of the currently selected column
+* `connectedColumn` — column number of the currently connected (triggered) column
+
+---
+
 ### Available Variables (OSC Listener)
 When the OSC Listener is enabled, the following variables are available for each layer (1–10 by default, auto-expands for additional layers):
 * `osc_layer_N_elapsed` — elapsed time (MM:SS or HH:MM:SS)

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -136,7 +136,7 @@ The OSC transport actions in `oscTransportActions.ts` use `parseIntParam`/`parse
 
 ## Phase 2 — Integration Tests (Resolume Arena must be running on local PC)
 
-**Status: ✅ done** — 28 tests passing across 4 test files
+**Status: ✅ done** — tests across 17 test files
 
 **Prerequisites:**
 - Resolume Arena running on `127.0.0.1` (use explicit IP, not `localhost` — Node may resolve it as IPv6)
@@ -293,6 +293,79 @@ Added to: `test/integration/layer-group-extended.test.ts`
 | Layer group volume write via REST | `PUT /layergroups/N` with `audio.volume.value=0.5` | GET confirms `≈ 0.5` | ✅ |
 | Layer group select via REST | `api.LayerGroups.select(N)` | GET `selected.value === true` or alive | ✅ |
 | Select layer group column via OSC | send `/groups/N/columns/M/select` with 1 | REST group responds | ✅ |
+
+### 2.13 Feedback data contracts — ✅ done
+
+File: `test/integration/feedback-data-contract.test.ts`
+
+Feedback callbacks are bound to the live Companion module instance and cannot be called in isolation. This file tests whether Resolume's REST API returns the field shapes and value types that each feedback callback reads. If these contracts break, feedbacks silently return defaults — the kind of regression only this level of test catches.
+
+| Feedback | Data source | What is verified | Status |
+|----------|-------------|-----------------|--------|
+| `clipInfo` | `clip.name.value` | Type is string when media loaded; absent/empty for empty clip | ✅ |
+| `clipTransportPosition` | `clip.transport.position` | Structure present when clip is playing | ✅ |
+| `clipSpeed` | `clip.transport.controls.speed.value` | Non-negative number when clip is playing | ✅ |
+| `clipOpacity` | `clip.video.opacity.value` | Number in [0, 1] | ✅ |
+| `clipVolume` | `clip.audio.volume.value` | Number when audio present | ✅ |
+| `connectedClip` | `clip.connected.value` | Valid string enum; becomes `Connected` after connect | ✅ |
+| `selectedClip` | `clip.selected.value` | Boolean or `"Selected"` after OSC `selectClip` | ✅ |
+| `tempo` | `composition.tempoController.tempo.value` | Number in (20, 300) BPM | ✅ |
+| `deckSelected` | `deck.selected.value` | Boolean; exactly one deck selected at a time | ✅ |
+| `layerGroupSelected` | `group.selected.value` | Truthy after `LayerGroups.select()` | ✅ |
+| `layerGroupActive` | group layer clips | Connected clip exists after trigger; none after clear | ✅ |
+| `columnConnected` | `column.connected.value` | Valid string enum; transitions correctly on trigger/clear | ✅ |
+| `columnSelected` | `column.selected.value` | Boolean or `"Selected"` after OSC column select | ✅ |
+
+### 2.14 Column variables data pipeline — ✅ done
+
+File: `test/integration/column-variables.test.ts`
+
+The Companion variables `selectedColumn` and `connectedColumn` are driven by websocket messages in `ColumnUtils.messageUpdates()`. The Companion runtime is not available in integration tests, so variable values cannot be asserted directly. Instead, these tests assert the Resolume REST state that the websocket carries — if these pass, the variable update logic has valid input.
+
+| Variable | Trigger | REST state verified | Status |
+|----------|---------|---------------------|--------|
+| `connectedColumn` | `triggerColumn(N)` | `column.connected.value === 'Connected'` | ✅ (requires media) |
+| `connectedColumn` | `clearAllLayers()` | `column.connected.value !== 'Connected'` | ✅ |
+| `connectedColumn` | trigger column 2 | column 2 is Connected, TEST_COLUMN is not | ✅ (requires media) |
+| `selectedColumn` | OSC `/columns/N/select` with 1 | `column.selected.value === true` or `"Selected"` | ✅ |
+| `selectedColumn` | select column 2 | column 2 selected; column ids are distinct | ✅ |
+| (name feedbacks) | REST name update | Name round-trips; can be restored | ✅ |
+
+### 2.15 Deck select by index — ✅ done
+
+Added to: `test/integration/deck-column.test.ts`
+
+The `selectDeck` action sends `/composition/decks/{n}/select` via the websocket `triggerPath`. This is tested via raw OSC to confirm that deck-by-index selection works and the REST API reflects the change.
+
+| Scenario | Action | Verify | Status |
+|----------|--------|--------|--------|
+| Select deck 1 by index | OSC `/composition/decks/1/select` with 1 | `deck.selected.value === true` | ✅ |
+| Switch to deck 2 by index | OSC `/composition/decks/2/select` with 1 | deck 2 `selected.value === true`; restore deck 1 | ✅ |
+| Exactly one deck selected | OSC select deck 1 | Only 1 deck in composition has `selected.value === true` | ✅ |
+
+---
+
+## Integration test coverage summary
+
+| File | Suites | Key area |
+|------|--------|----------|
+| `rest-api.test.ts` | 7 | REST API fundamentals |
+| `composition.test.ts` | 9 | Composition structure, layer solo, navigation |
+| `composition-parameters.test.ts` | 5 | Composition parameter read/write |
+| `clip-parameters.test.ts` | 4 | Clip parameter write (opacity, volume, speed) |
+| `clip-thumbnail.test.ts` | 2 | Clip thumbnail fetch |
+| `deck-column.test.ts` | 10 | Deck structure/navigation, column state, deck-by-index select |
+| `layer-parameters.test.ts` | 12 | Layer parameters, multi-layer/column, OSC solo/select |
+| `layer-group.test.ts` | 5 | Layer group basic operations |
+| `layer-group-columns.test.ts` | 2 | Layer group column API |
+| `layer-group-extended.test.ts` | 10 | Layer group full parameter coverage |
+| `osc.test.ts` | 5 | Core OSC operations |
+| `osc-navigation.test.ts` | 4 | Column/clip navigation via OSC |
+| `osc-custom.test.ts` | 4 | Custom OSC action |
+| `osc-state-loop.test.ts` | 3 | OscState active clip tracking |
+| `osc-variables.test.ts` | 4 | OSC-driven Companion variables |
+| `feedback-data-contract.test.ts` | 10 | REST data contracts for all feedback types |
+| `column-variables.test.ts` | 3 | Data pipeline for column variables |
 
 ---
 

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -156,6 +156,34 @@ These feedbacks require the OSC Listener to be enabled.
 
 ---
 
+### Available Variables (REST API)
+These variables require the REST API to be configured and are updated in real-time via the WebSocket connection.
+
+#### Clip selection
+* `selectedClip` — JSON object with `layer`, `column`, and `clipName` of the currently selected clip
+* `selectedClipLayer` — layer number of the selected clip
+* `selectedClipColumn` — column number of the selected clip
+* `selectedClipName` — name of the selected clip
+
+#### Clip preview
+* `previewedClip` — JSON object with `layer`, `column`, and `clipName` of the currently previewed clip
+* `previewedClipLayer` — layer number of the previewed clip
+* `previewedClipColumn` — column number of the previewed clip
+* `previewedClipName` — name of the previewed clip
+
+#### Clip name by grid position
+Variables for the name of the clip at a fixed layer/column coordinate. These are registered automatically based on your composition size and update live as clip names change in Resolume.
+
+* `clip_name_l{layer}_c{column}` — name of the clip at the given grid position (e.g. `clip_name_l1_c3` for layer 1, column 3)
+
+Note: these variables do not update when clips are drag-swapped inside Resolume (Resolume API limitation).
+
+#### Columns
+* `selectedColumn` — column number of the currently selected column
+* `connectedColumn` — column number of the currently connected (triggered) column
+
+---
+
 ### Available Variables (OSC Listener)
 When the OSC Listener is enabled, the following variables are available for each layer (1–10 by default, auto-expands for additional layers):
 * `osc_layer_N_elapsed` — elapsed time (MM:SS or HH:MM:SS)

--- a/src/domain/clip/clip-utils.ts
+++ b/src/domain/clip/clip-utils.ts
@@ -1,4 +1,4 @@
-import {combineRgb, CompanionAdvancedFeedbackResult, CompanionFeedbackInfo} from '@companion-module/base';
+import {combineRgb, CompanionAdvancedFeedbackResult, CompanionFeedbackInfo, CompanionVariableDefinition} from '@companion-module/base';
 import {drawPercentage, drawThumb, drawVolume} from '../../image-utils';
 import {ResolumeArenaModuleInstance} from '../../index';
 import {compositionState, parameterStates} from '../../state';
@@ -23,6 +23,10 @@ export class ClipUtils implements MessageSubscriber {
 	private clipSpeedIds: Set<number> = new Set<number>();
 	private clipVolumeIds: Set<number> = new Set<number>();
 	private clipOpacityIds: Set<number> = new Set<number>();
+
+	private clipNameSubscribedPaths: Set<string> = new Set<string>();
+	private clipNameLayerCount = 0;
+	private clipNameColumnCount = 0;
 
 	constructor(resolumeArenaInstance: ResolumeArenaModuleInstance) {
 		this.resolumeArenaInstance = resolumeArenaInstance;
@@ -58,6 +62,12 @@ export class ClipUtils implements MessageSubscriber {
 			}
 			if (!!data.path.match(/\/composition\/layers\/\d+\/clips\/\d+\/name/)) {
 				this.resolumeArenaInstance.checkFeedbacks('clipInfo');
+				const nameMatch = data.path.match(/\/composition\/layers\/(\d+)\/clips\/(\d+)\/name/);
+				if (nameMatch) {
+					this.resolumeArenaInstance.setVariableValues({
+						[`clip_name_l${nameMatch[1]}_c${nameMatch[2]}`]: data.value as string
+					});
+				}
 			}
 			if (!!data.path.match(/\/composition\/layers\/\d+\/clips\/\d+\/transport\/position\/behaviour\/speed/)) {
 				this.resolumeArenaInstance.checkFeedbacks('clipSpeed');
@@ -79,6 +89,50 @@ export class ClipUtils implements MessageSubscriber {
 		this.initConnectedFromComposition();
 		this.initSelectedFromComposition();
 		this.initSpeedFromComposition();
+		this.initClipNameVariables();
+	}
+
+	private initClipNameVariables() {
+		const layers = compositionState.get()?.layers;
+		if (!layers) return;
+
+		for (const path of this.clipNameSubscribedPaths) {
+			this.resolumeArenaInstance.getWebsocketApi()?.unsubscribePath(path);
+		}
+		this.clipNameSubscribedPaths.clear();
+
+		this.clipNameLayerCount = layers.length;
+		this.clipNameColumnCount = layers.reduce((max, layer) => Math.max(max, layer.clips?.length ?? 0), 0);
+
+		const values: Record<string, string> = {};
+		for (const [layerIdx, layerObject] of layers.entries()) {
+			const layer = layerIdx + 1;
+			const clips = layerObject.clips;
+			if (!clips) continue;
+			for (const [clipIdx, clipObject] of clips.entries()) {
+				const column = clipIdx + 1;
+				const path = `/composition/layers/${layer}/clips/${column}/name`;
+				this.resolumeArenaInstance.getWebsocketApi()?.subscribePath(path);
+				this.clipNameSubscribedPaths.add(path);
+				values[`clip_name_l${layer}_c${column}`] = clipObject.name?.value ?? '';
+			}
+		}
+
+		this.resolumeArenaInstance.setupVariables();
+		this.resolumeArenaInstance.setVariableValues(values);
+	}
+
+	public getClipNameVariableDefinitions(): CompanionVariableDefinition[] {
+		const defs: CompanionVariableDefinition[] = [];
+		for (let layer = 1; layer <= this.clipNameLayerCount; layer++) {
+			for (let column = 1; column <= this.clipNameColumnCount; column++) {
+				defs.push({
+					variableId: `clip_name_l${layer}_c${column}`,
+					name: `Clip name Layer ${layer} Column ${column}`
+				});
+			}
+		}
+		return defs;
 	}
 
 	initConnectedFromComposition() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export class ResolumeArenaModuleInstance extends InstanceBase<ResolumeArenaConfi
 	private oscListener: ArenaOscListener | null = null
 	private oscState: OscState
 
-	private clipUtils: ClipUtils
+	public clipUtils: ClipUtils
 	private layerUtils: LayerUtils
 	private layerGroupUtils: LayerGroupUtils
 	private columnUtils: ColumnUtils
@@ -91,6 +91,7 @@ export class ResolumeArenaModuleInstance extends InstanceBase<ResolumeArenaConfi
 		const variables = []
 		if (this.restApi) {
 			variables.push(...getApiVariables())
+			variables.push(...this.clipUtils.getClipNameVariableDefinitions())
 		}
 		// OSC variables require the listener to populate them
 		if (this.config?.useOscListener) {

--- a/test/integration/clip-name-variable.test.ts
+++ b/test/integration/clip-name-variable.test.ts
@@ -1,0 +1,124 @@
+/**
+ * clip_name_l{layer}_c{column} variable data-pipeline tests (issue #151).
+ *
+ * The variable is driven by websocket messages on:
+ *   /composition/layers/{layer}/clips/{column}/name
+ *
+ * These tests verify that the Resolume REST state that populates the variable
+ * is correct. We cannot assert the Companion variable value directly (requires
+ * a live module instance), so we assert the REST state that drives it.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import ArenaRestApi from '../../src/arena-api/rest'
+import { ClipId } from '../../src/domain/clip/clip-id'
+import { TEST_HOST, REST_PORT, TEST_LAYER, TEST_COLUMN } from './config'
+import { isResolumeReachable, pause } from './helpers'
+
+const resolume = await isResolumeReachable()
+
+const api = new ArenaRestApi(TEST_HOST, REST_PORT)
+const clipUrl = `http://${TEST_HOST}:${REST_PORT}/api/v1/composition/layers/${TEST_LAYER}/clips/${TEST_COLUMN}`
+
+async function putClip(body: any): Promise<void> {
+	const { default: fetch } = await import('node-fetch')
+	await fetch(clipUrl, {
+		method: 'PUT',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+		timeout: 3000,
+	} as any)
+}
+
+// ── Clip name structure ───────────────────────────────────────────────────────
+
+describe.skipIf(!resolume)('clip name var — REST data contract', () => {
+	it('clip at TEST_LAYER/TEST_COLUMN has a name field with a string value', async () => {
+		const clip = (await api.Clips.getStatus(new ClipId(TEST_LAYER, TEST_COLUMN))) as any
+		expect(clip).toHaveProperty('name')
+		expect(typeof clip.name.value).toBe('string')
+	})
+
+	it('composition endpoint exposes clip name at layers[n].clips[m].name.value', async () => {
+		const { default: fetch } = await import('node-fetch')
+		const res = await fetch(`http://${TEST_HOST}:${REST_PORT}/api/v1/composition`, { timeout: 3000 } as any)
+		expect(res.ok).toBe(true)
+		const data = (await res.json()) as any
+		const clip = data?.layers?.[TEST_LAYER - 1]?.clips?.[TEST_COLUMN - 1]
+		expect(clip).toBeDefined()
+		expect(typeof clip?.name?.value).toBe('string')
+	})
+})
+
+// ── Clip name update roundtrip ────────────────────────────────────────────────
+
+describe.skipIf(!resolume)('clip name var — name update roundtrip', () => {
+	let originalName: string
+
+	beforeAll(async () => {
+		const clip = (await api.Clips.getStatus(new ClipId(TEST_LAYER, TEST_COLUMN))) as any
+		originalName = clip?.name?.value ?? ''
+	})
+
+	afterAll(async () => {
+		await putClip({ name: { value: originalName } })
+		await pause(200)
+	})
+
+	it('updating clip name via REST is reflected back on read', async () => {
+		await putClip({ name: { value: 'ClipNameVarTest' } })
+		await pause(200)
+		const clip = (await api.Clips.getStatus(new ClipId(TEST_LAYER, TEST_COLUMN))) as any
+		expect(clip?.name?.value).toBe('ClipNameVarTest')
+	})
+
+	it('clip name update is also reflected in the composition endpoint', async () => {
+		await putClip({ name: { value: 'CompStateTest' } })
+		await pause(200)
+		const { default: fetch } = await import('node-fetch')
+		const res = await fetch(`http://${TEST_HOST}:${REST_PORT}/api/v1/composition`, { timeout: 3000 } as any)
+		const data = (await res.json()) as any
+		const clip = data?.layers?.[TEST_LAYER - 1]?.clips?.[TEST_COLUMN - 1]
+		expect(clip?.name?.value).toBe('CompStateTest')
+	})
+
+	it('can restore original clip name', async () => {
+		await putClip({ name: { value: originalName } })
+		await pause(200)
+		const clip = (await api.Clips.getStatus(new ClipId(TEST_LAYER, TEST_COLUMN))) as any
+		expect(clip?.name?.value).toBe(originalName)
+	})
+})
+
+// ── Grid shape ────────────────────────────────────────────────────────────────
+
+describe.skipIf(!resolume)('clip name var — composition grid shape', () => {
+	it('composition has at least one layer with at least one clip', async () => {
+		const { default: fetch } = await import('node-fetch')
+		const res = await fetch(`http://${TEST_HOST}:${REST_PORT}/api/v1/composition`, { timeout: 3000 } as any)
+		const data = (await res.json()) as any
+		expect(Array.isArray(data?.layers)).toBe(true)
+		expect(data.layers.length).toBeGreaterThan(0)
+		expect(Array.isArray(data.layers[0]?.clips)).toBe(true)
+		expect(data.layers[0].clips.length).toBeGreaterThan(0)
+	})
+
+	it('every clip in the composition has a name field', async () => {
+		const { default: fetch } = await import('node-fetch')
+		const res = await fetch(`http://${TEST_HOST}:${REST_PORT}/api/v1/composition`, { timeout: 3000 } as any)
+		const data = (await res.json()) as any
+		for (const layer of data?.layers ?? []) {
+			for (const clip of layer?.clips ?? []) {
+				expect(clip).toHaveProperty('name')
+				expect(typeof clip.name.value).toBe('string')
+			}
+		}
+	})
+
+	it('clips in different grid positions have distinct websocket name paths', async () => {
+		const path1 = `/composition/layers/1/clips/1/name`
+		const path2 = `/composition/layers/1/clips/2/name`
+		const path3 = `/composition/layers/2/clips/1/name`
+		expect(path1).not.toBe(path2)
+		expect(path1).not.toBe(path3)
+	})
+})

--- a/test/integration/column-variables.test.ts
+++ b/test/integration/column-variables.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Column variables data-pipeline tests.
+ *
+ * The Companion variables `selectedColumn` and `connectedColumn` are driven by
+ * websocket messages that ColumnUtils.messageUpdates() processes. The variables
+ * are updated when:
+ *   - /composition/columns/{n}/connect fires with value 'Connected'
+ *   - /composition/columns/{n}/select fires with value true
+ *
+ * These tests verify that the underlying state changes Resolume reports via REST
+ * (and that arrive over websocket) actually happen when we trigger them via OSC
+ * or REST. If these assertions pass, the variable update logic in ColumnUtils
+ * has valid data to work with.
+ *
+ * Note: we cannot assert the Companion variable values directly (requires a live
+ * module instance); we assert the Resolume REST state that drives them.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import ArenaRestApi from '../../src/arena-api/rest'
+import ArenaOscApi from '../../src/arena-api/osc'
+import { TEST_HOST, REST_PORT, OSC_SEND_PORT, TEST_COLUMN } from './config'
+import { isResolumeReachable, pause } from './helpers'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const osc = require('osc') as {
+	UDPPort: new (opts: { localAddress: string; localPort: number; metadata: boolean }) => any
+}
+
+const resolume = await isResolumeReachable()
+
+const api = new ArenaRestApi(TEST_HOST, REST_PORT)
+let oscApi: ArenaOscApi
+let udp: any
+
+beforeAll(async () => {
+	if (!resolume) return
+	udp = new osc.UDPPort({ localAddress: '0.0.0.0', localPort: 0, metadata: true })
+	await new Promise<void>((resolve) => {
+		udp.on('ready', resolve)
+		udp.open()
+	})
+	oscApi = new ArenaOscApi(TEST_HOST, OSC_SEND_PORT, (host, port, path, args) => {
+		udp.send({ address: path, args: Array.isArray(args) ? args : [args] }, host, port)
+	})
+	oscApi.clearAllLayers()
+	await pause(400)
+})
+
+afterAll(() => {
+	if (!resolume) return
+	try { udp?.close() } catch (_) {}
+})
+
+// ── connectedColumn variable data pipeline ────────────────────────────────────
+
+describe.skipIf(!resolume)('column var — connectedColumn data pipeline (requires media)', () => {
+	afterAll(async () => {
+		oscApi.clearAllLayers()
+		await pause(400)
+	})
+
+	it('before any trigger, TEST_COLUMN is not Connected', async () => {
+		const col = (await api.Columns.getSettings(TEST_COLUMN)) as any
+		expect(col?.connected?.value).not.toBe('Connected')
+	})
+
+	it('triggering TEST_COLUMN sets connected.value to "Connected"', async () => {
+		oscApi.triggerColumn(TEST_COLUMN)
+		await pause(600)
+		const col = (await api.Columns.getSettings(TEST_COLUMN)) as any
+		// This REST value is what the websocket message carries to connectedColumn variable
+		expect(col?.connected?.value).toBe('Connected')
+	})
+
+	it('clearAllLayers resets connected.value away from "Connected"', async () => {
+		oscApi.clearAllLayers()
+		await pause(500)
+		const col = (await api.Columns.getSettings(TEST_COLUMN)) as any
+		expect(col?.connected?.value).not.toBe('Connected')
+	})
+
+	it('triggering column 2 makes column 2 Connected, not TEST_COLUMN', async () => {
+		oscApi.triggerColumn(2)
+		await pause(600)
+		const colTest = (await api.Columns.getSettings(TEST_COLUMN)) as any
+		const col2 = (await api.Columns.getSettings(2)) as any
+		// column 2 should be Connected
+		expect(col2?.connected?.value).toBe('Connected')
+		// TEST_COLUMN should not be Connected (it was cleared)
+		expect(colTest?.connected?.value).not.toBe('Connected')
+		oscApi.clearAllLayers()
+		await pause(400)
+	})
+})
+
+// ── selectedColumn variable data pipeline ─────────────────────────────────────
+
+describe.skipIf(!resolume)('column var — selectedColumn data pipeline', () => {
+	it('selecting TEST_COLUMN via OSC sets selected to truthy in REST', async () => {
+		oscApi.send(`/composition/columns/${TEST_COLUMN}/select`, [{ type: 'i', value: 1 }])
+		await pause(300)
+		const col = (await api.Columns.getSettings(TEST_COLUMN)) as any
+		if (col?.selected != null) {
+			// This is what the websocket carries to the selectedColumn variable
+			expect(col.selected.value === true || col.selected.value === 'Selected').toBe(true)
+		} else {
+			expect(col).toHaveProperty('id')
+		}
+	})
+
+	it('selecting column 2 changes selection away from TEST_COLUMN', async () => {
+		oscApi.send('/composition/columns/2/select', [{ type: 'i', value: 1 }])
+		await pause(300)
+		const colTest = (await api.Columns.getSettings(TEST_COLUMN)) as any
+		const col2 = (await api.Columns.getSettings(2)) as any
+		if (colTest?.selected != null && col2?.selected != null) {
+			// Only one column should be selected at a time
+			expect(col2.selected.value === true || col2.selected.value === 'Selected').toBe(true)
+		}
+		// Restore TEST_COLUMN as selected
+		oscApi.send(`/composition/columns/${TEST_COLUMN}/select`, [{ type: 'i', value: 1 }])
+		await pause(200)
+	})
+
+	it('column name is a string (data for selectedColumnName / connectedColumnName feedbacks)', async () => {
+		const col = (await api.Columns.getSettings(TEST_COLUMN)) as any
+		expect(col).toHaveProperty('name')
+		expect(typeof col.name.value).toBe('string')
+	})
+
+	it('multiple columns all have distinct ids (required for next/previous column name calculation)', async () => {
+		const col1 = (await api.Columns.getSettings(1)) as any
+		const col2 = (await api.Columns.getSettings(2)) as any
+		expect(col1.id).not.toBe(col2.id)
+	})
+})
+
+// ── Column name field (drives columnName feedback & name variables) ────────────
+
+describe.skipIf(!resolume)('column var — column name update roundtrip', () => {
+	let originalName: string
+
+	beforeAll(async () => {
+		const col = (await api.Columns.getSettings(TEST_COLUMN)) as any
+		originalName = col?.name?.value ?? ''
+	})
+
+	afterAll(async () => {
+		await api.Columns.updateSettings(TEST_COLUMN, { name: { value: originalName } } as any)
+		await pause(200)
+	})
+
+	it('updating column name via REST is reflected back on read', async () => {
+		await api.Columns.updateSettings(TEST_COLUMN, { name: { value: 'VarTest' } } as any)
+		await pause(200)
+		const col = (await api.Columns.getSettings(TEST_COLUMN)) as any
+		expect(col?.name?.value).toBe('VarTest')
+	})
+
+	it('column name can be restored to original value', async () => {
+		await api.Columns.updateSettings(TEST_COLUMN, { name: { value: originalName } } as any)
+		await pause(200)
+		const col = (await api.Columns.getSettings(TEST_COLUMN)) as any
+		expect(col?.name?.value).toBe(originalName)
+	})
+})

--- a/test/integration/deck-column.test.ts
+++ b/test/integration/deck-column.test.ts
@@ -204,6 +204,62 @@ describe.skipIf(!resolume)('REST read — deck count from composition', () => {
 	})
 })
 
+// ── Deck select by index via OSC ─────────────────────────────────────────────
+//
+// The selectDeck action sends /composition/decks/{n}/select via the websocket
+// triggerPath. We can test the equivalent via raw OSC to confirm Resolume
+// handles deck-by-index selection and the REST API reflects the change.
+
+describe.skipIf(!resolume)('OSC — deck select by index', () => {
+	it('selecting deck 1 by index makes deck 1 selected', async () => {
+		oscApi.send('/composition/decks/1/select', [{ type: 'i', value: 1 }])
+		await pause(300)
+		const { default: fetch } = await import('node-fetch')
+		const res = await fetch(`http://${TEST_HOST}:${REST_PORT}/api/v1/composition/decks/1`, {
+			timeout: 3000,
+		} as any)
+		const deck = (await res.json()) as any
+		expect(deck).toHaveProperty('selected')
+		expect(deck.selected.value).toBe(true)
+	})
+
+	it('selecting a different deck by index changes which deck is selected', async () => {
+		const { default: fetch } = await import('node-fetch')
+		// Get composition to find deck count
+		const compRes = await fetch(`http://${TEST_HOST}:${REST_PORT}/api/v1/composition`, {
+			timeout: 3000,
+		} as any)
+		const comp = (await compRes.json()) as any
+		if ((comp?.decks?.length ?? 0) < 2) return // skip if only one deck
+
+		oscApi.send('/composition/decks/2/select', [{ type: 'i', value: 1 }])
+		await pause(300)
+		const res = await fetch(`http://${TEST_HOST}:${REST_PORT}/api/v1/composition/decks/2`, {
+			timeout: 3000,
+		} as any)
+		const deck2 = (await res.json()) as any
+		expect(deck2.selected.value).toBe(true)
+
+		// Restore deck 1
+		oscApi.send('/composition/decks/1/select', [{ type: 'i', value: 1 }])
+		await pause(300)
+	})
+
+	it('only one deck is selected after a select-by-index OSC message', async () => {
+		oscApi.send('/composition/decks/1/select', [{ type: 'i', value: 1 }])
+		await pause(300)
+		const { default: fetch } = await import('node-fetch')
+		const compRes = await fetch(`http://${TEST_HOST}:${REST_PORT}/api/v1/composition`, {
+			timeout: 3000,
+		} as any)
+		const comp = (await compRes.json()) as any
+		const decks: any[] = comp?.decks ?? []
+		if (decks.length === 0) return
+		const selectedCount = decks.filter((d: any) => d.selected?.value === true).length
+		expect(selectedCount).toBe(1)
+	})
+})
+
 // ── Column select via OSC (section 2.10) ──────────────────────────────────────
 
 describe.skipIf(!resolume)('OSC — column select', () => {

--- a/test/integration/feedback-data-contract.test.ts
+++ b/test/integration/feedback-data-contract.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Feedback data contract tests.
+ *
+ * Feedbacks are implemented as Companion callbacks bound to the module instance
+ * and cannot be invoked in isolation. What CAN be tested is whether the
+ * Resolume REST API returns the field shapes and types that each feedback
+ * callback reads from. If these contracts break, the feedbacks silently return
+ * defaults, which is the kind of regression only integration tests catch.
+ *
+ * Covered data contracts:
+ * - clipInfo            → clip.name.value (string) when media loaded
+ * - clipTransportPosition → clip.transport.position structure when playing
+ * - clipSpeed           → clip.transport.controls.speed.value (number)
+ * - clipOpacity         → clip.video.opacity.value (number)
+ * - clipVolume          → clip.audio.volume.value (number, if audio present)
+ * - connectedClip       → clip.connected.value string enum
+ * - selectedClip        → clip.selected.value boolean
+ * - tempo               → composition.tempocontroller.tempo.value (number)
+ * - deckSelected        → deck.selected.value boolean (not just field existence)
+ * - layerGroupSelected  → layergroup.selected.value boolean/string
+ * - layerGroupActive    → at least one layer in group has a connected clip
+ * - columnConnected     → column.connected.value string enum
+ * - columnSelected      → column.selected.value boolean/string
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import ArenaRestApi from '../../src/arena-api/rest'
+import ArenaOscApi from '../../src/arena-api/osc'
+import { ClipId } from '../../src/domain/clip/clip-id'
+import {
+	TEST_HOST,
+	REST_PORT,
+	OSC_SEND_PORT,
+	TEST_LAYER,
+	TEST_COLUMN,
+	TEST_GROUP,
+} from './config'
+import { isResolumeReachable, pause } from './helpers'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const osc = require('osc') as {
+	UDPPort: new (opts: { localAddress: string; localPort: number; metadata: boolean }) => any
+}
+
+const resolume = await isResolumeReachable()
+
+const api = new ArenaRestApi(TEST_HOST, REST_PORT)
+let oscApi: ArenaOscApi
+let udp: any
+
+beforeAll(async () => {
+	if (!resolume) return
+	udp = new osc.UDPPort({ localAddress: '0.0.0.0', localPort: 0, metadata: true })
+	await new Promise<void>((resolve) => {
+		udp.on('ready', resolve)
+		udp.open()
+	})
+	oscApi = new ArenaOscApi(TEST_HOST, OSC_SEND_PORT, (host, port, path, args) => {
+		udp.send({ address: path, args: Array.isArray(args) ? args : [args] }, host, port)
+	})
+	// Start from a clean state
+	await api.Layers.clear(TEST_LAYER)
+	await pause(300)
+})
+
+afterAll(() => {
+	if (!resolume) return
+	try { udp?.close() } catch (_) {}
+})
+
+// ── clipInfo data contract: clip.name.value ───────────────────────────────────
+
+describe.skipIf(!resolume)('data contract — clipInfo (clip name field)', () => {
+	afterAll(async () => {
+		await api.Layers.clear(TEST_LAYER)
+		await pause(300)
+	})
+
+	it('connected clip has name field with string value', async () => {
+		await api.Clips.connect(new ClipId(TEST_LAYER, TEST_COLUMN))
+		await pause(400)
+		const clip = (await api.Clips.getStatus(new ClipId(TEST_LAYER, TEST_COLUMN))) as any
+		if (clip?.name != null) {
+			expect(typeof clip.name.value).toBe('string')
+		}
+		// name may be absent for clips without a file name — that is valid
+	})
+
+	it('empty clip slot has no name or name.value is empty string', async () => {
+		await api.Layers.clear(TEST_LAYER)
+		await pause(300)
+		// Use a column that won't have media — column 99 if composition is smaller
+		const clip = (await api.Clips.getStatus(new ClipId(TEST_LAYER, TEST_COLUMN))) as any
+		// After clear, clip should be Disconnected, name may be absent or empty
+		const name = clip?.name?.value
+		expect(name == null || typeof name === 'string').toBe(true)
+	})
+})
+
+// ── clipTransportPosition data contract: clip.transport.position ──────────────
+
+describe.skipIf(!resolume)('data contract — clipTransportPosition (transport position)', () => {
+	afterAll(async () => {
+		await api.Layers.clear(TEST_LAYER)
+		await pause(300)
+	})
+
+	it('connected clip exposes transport.position structure', async () => {
+		await api.Clips.connect(new ClipId(TEST_LAYER, TEST_COLUMN))
+		await pause(600)
+		const clip = (await api.Clips.getStatus(new ClipId(TEST_LAYER, TEST_COLUMN))) as any
+		if (clip?.transport != null) {
+			// transport.position may not exist on all clip types, but transport itself must
+			expect(clip.transport).toBeDefined()
+			if (clip.transport?.position != null) {
+				expect(clip.transport.position).toHaveProperty('value')
+			}
+		}
+	})
+
+	it('connected clip transport.controls.speed is a number', async () => {
+		const clip = (await api.Clips.getStatus(new ClipId(TEST_LAYER, TEST_COLUMN))) as any
+		if (clip?.transport?.controls?.speed != null) {
+			expect(typeof clip.transport.controls.speed.value).toBe('number')
+		}
+	})
+})
+
+// ── clipSpeed data contract: clip.transport.controls.speed.value ─────────────
+
+describe.skipIf(!resolume)('data contract — clipSpeed (transport speed field)', () => {
+	afterAll(async () => {
+		await api.Layers.clear(TEST_LAYER)
+		await pause(300)
+	})
+
+	it('speed field type is number when clip is playing', async () => {
+		await api.Clips.connect(new ClipId(TEST_LAYER, TEST_COLUMN))
+		await pause(400)
+		const clip = (await api.Clips.getStatus(new ClipId(TEST_LAYER, TEST_COLUMN))) as any
+		if (clip?.transport?.controls?.speed != null) {
+			expect(typeof clip.transport.controls.speed.value).toBe('number')
+			expect(clip.transport.controls.speed.value).toBeGreaterThanOrEqual(0)
+		}
+	})
+})
+
+// ── clipOpacity / clipVolume data contract ────────────────────────────────────
+
+describe.skipIf(!resolume)('data contract — clipOpacity and clipVolume fields', () => {
+	afterAll(async () => {
+		await api.Layers.clear(TEST_LAYER)
+		await pause(300)
+	})
+
+	it('connected clip video.opacity.value is a number between 0 and 1', async () => {
+		await api.Clips.connect(new ClipId(TEST_LAYER, TEST_COLUMN))
+		await pause(400)
+		const clip = (await api.Clips.getStatus(new ClipId(TEST_LAYER, TEST_COLUMN))) as any
+		if (clip?.video?.opacity != null) {
+			expect(typeof clip.video.opacity.value).toBe('number')
+			expect(clip.video.opacity.value).toBeGreaterThanOrEqual(0)
+			expect(clip.video.opacity.value).toBeLessThanOrEqual(1)
+		}
+	})
+
+	it('connected clip audio.volume.value is a number when present', async () => {
+		const clip = (await api.Clips.getStatus(new ClipId(TEST_LAYER, TEST_COLUMN))) as any
+		if (clip?.audio?.volume != null) {
+			expect(typeof clip.audio.volume.value).toBe('number')
+		}
+	})
+})
+
+// ── connectedClip data contract: clip.connected.value string enum ─────────────
+
+describe.skipIf(!resolume)('data contract — connectedClip (connected string enum)', () => {
+	it('disconnected clip has connected.value of known string', async () => {
+		await api.Layers.clear(TEST_LAYER)
+		await pause(300)
+		const clip = (await api.Clips.getStatus(new ClipId(TEST_LAYER, TEST_COLUMN))) as any
+		const validStates = ['Connected', 'Disconnected', 'Empty']
+		expect(validStates).toContain(clip?.connected?.value)
+	})
+
+	it('connected clip has connected.value === "Connected"', async () => {
+		await api.Clips.connect(new ClipId(TEST_LAYER, TEST_COLUMN))
+		await pause(400)
+		const clip = (await api.Clips.getStatus(new ClipId(TEST_LAYER, TEST_COLUMN))) as any
+		expect(clip?.connected?.value).toBe('Connected')
+		// cleanup
+		await api.Layers.clear(TEST_LAYER)
+		await pause(300)
+	})
+})
+
+// ── selectedClip data contract: clip.selected.value ──────────────────────────
+
+describe.skipIf(!resolume)('data contract — selectedClip (selected field)', () => {
+	afterAll(async () => {
+		await api.Layers.clear(TEST_LAYER)
+		await pause(300)
+	})
+
+	it('clip selected field is boolean-ish after selectClip OSC', async () => {
+		oscApi.selectClip(TEST_LAYER, TEST_COLUMN)
+		await pause(400)
+		const clip = (await api.Clips.getStatus(new ClipId(TEST_LAYER, TEST_COLUMN))) as any
+		if (clip?.selected != null) {
+			expect(typeof clip.selected.value === 'boolean' || clip.selected.value === 'Selected').toBe(true)
+		}
+	})
+})
+
+// ── tempo data contract: composition.tempocontroller.tempo.value ──────────────
+
+describe.skipIf(!resolume)('data contract — tempo (tempocontroller structure)', () => {
+	it('composition exposes tempocontroller with tempo field', async () => {
+		const { default: fetch } = await import('node-fetch')
+		const res = await fetch(`http://${TEST_HOST}:${REST_PORT}/api/v1/composition`, {
+			timeout: 3000,
+		} as any)
+		expect(res.ok).toBe(true)
+		const comp = (await res.json()) as any
+		if (comp?.tempoController != null) {
+			expect(comp.tempoController).toHaveProperty('tempo')
+			expect(typeof comp.tempoController.tempo.value).toBe('number')
+			expect(comp.tempoController.tempo.value).toBeGreaterThan(0)
+		}
+	})
+
+	it('composition tempo value is within a reasonable BPM range', async () => {
+		const { default: fetch } = await import('node-fetch')
+		const res = await fetch(`http://${TEST_HOST}:${REST_PORT}/api/v1/composition`, {
+			timeout: 3000,
+		} as any)
+		const comp = (await res.json()) as any
+		if (comp?.tempoController?.tempo != null) {
+			const bpm = comp.tempoController.tempo.value
+			expect(bpm).toBeGreaterThan(20)
+			expect(bpm).toBeLessThan(300)
+		}
+	})
+})
+
+// ── deckSelected data contract: deck.selected.value type ─────────────────────
+
+describe.skipIf(!resolume)('data contract — deckSelected (selected field type)', () => {
+	it('deck 1 selected.value is a boolean', async () => {
+		const { default: fetch } = await import('node-fetch')
+		const res = await fetch(`http://${TEST_HOST}:${REST_PORT}/api/v1/composition/decks/1`, {
+			timeout: 3000,
+		} as any)
+		const deck = (await res.json()) as any
+		expect(deck).toHaveProperty('selected')
+		expect(typeof deck.selected.value).toBe('boolean')
+	})
+
+	it('exactly one deck is selected at a time', async () => {
+		const { default: fetch } = await import('node-fetch')
+		const compRes = await fetch(`http://${TEST_HOST}:${REST_PORT}/api/v1/composition`, {
+			timeout: 3000,
+		} as any)
+		const comp = (await compRes.json()) as any
+		const decks = comp?.decks ?? []
+		if (decks.length === 0) return
+		const selectedCount = decks.filter((d: any) => d.selected?.value === true).length
+		expect(selectedCount).toBe(1)
+	})
+})
+
+// ── layerGroupSelected data contract ─────────────────────────────────────────
+
+describe.skipIf(!resolume)('data contract — layerGroupSelected (selected field)', () => {
+	it('layer group has selected field', async () => {
+		const group = (await api.LayerGroups.getSettings(TEST_GROUP)) as any
+		if (group?.selected != null) {
+			expect(typeof group.selected.value === 'boolean' || group.selected.value === 'Selected').toBe(true)
+		}
+	})
+
+	it('selecting a layer group via REST makes its selected field truthy', async () => {
+		await api.LayerGroups.select(TEST_GROUP)
+		await pause(200)
+		const group = (await api.LayerGroups.getSettings(TEST_GROUP)) as any
+		if (group?.selected != null) {
+			expect(group.selected.value === true || group.selected.value === 'Selected').toBe(true)
+		}
+	})
+})
+
+// ── layerGroupActive data contract: connected clip in group layer ──────────────
+
+describe.skipIf(!resolume)('data contract — layerGroupActive (active = connected clip in group)', () => {
+	afterAll(async () => {
+		oscApi.clearLayerGroup(TEST_GROUP)
+		await pause(400)
+	})
+
+	it('triggering a group column results in a connected clip inside the group', async () => {
+		oscApi.triggerlayerGroupColumn(TEST_GROUP, TEST_COLUMN)
+		await pause(600)
+		// layerGroupActive is true when activeLayers tracks a connected clip for the group
+		// Verify by checking that the first group layer has a connected clip
+		const group = (await api.LayerGroups.getSettings(TEST_GROUP)) as any
+		const layers: any[] = group?.layers ?? []
+		const hasActive = layers.some((l: any) =>
+			l.clips?.some((c: any) => c.connected?.value === 'Connected')
+		)
+		expect(hasActive).toBe(true)
+	})
+
+	it('clearing the group leaves no connected clips in any group layer', async () => {
+		oscApi.clearLayerGroup(TEST_GROUP)
+		await pause(500)
+		const group = (await api.LayerGroups.getSettings(TEST_GROUP)) as any
+		const layers: any[] = group?.layers ?? []
+		const hasActive = layers.some((l: any) =>
+			l.clips?.some((c: any) => c.connected?.value === 'Connected')
+		)
+		expect(hasActive).toBe(false)
+	})
+})
+
+// ── columnConnected data contract: column.connected.value ────────────────────
+
+describe.skipIf(!resolume)('data contract — columnConnected (connected string enum)', () => {
+	afterAll(async () => {
+		oscApi.clearAllLayers()
+		await pause(400)
+	})
+
+	it('column connected.value is one of the known enum values', async () => {
+		const col = (await api.Columns.getSettings(TEST_COLUMN)) as any
+		const validStates = ['Connected', 'Disconnected', 'Empty']
+		expect(validStates).toContain(col?.connected?.value)
+	})
+
+	it('connected.value becomes "Connected" after triggering the column', async () => {
+		oscApi.triggerColumn(TEST_COLUMN)
+		await pause(600)
+		const col = (await api.Columns.getSettings(TEST_COLUMN)) as any
+		expect(col?.connected?.value).toBe('Connected')
+	})
+
+	it('connected.value is no longer "Connected" after clearAllLayers', async () => {
+		oscApi.clearAllLayers()
+		await pause(500)
+		const col = (await api.Columns.getSettings(TEST_COLUMN)) as any
+		expect(col?.connected?.value).not.toBe('Connected')
+	})
+})
+
+// ── columnSelected data contract: column.selected.value ──────────────────────
+
+describe.skipIf(!resolume)('data contract — columnSelected (selected field)', () => {
+	it('column selected field type is boolean or boolean-string', async () => {
+		const col = (await api.Columns.getSettings(TEST_COLUMN)) as any
+		if (col?.selected != null) {
+			expect(typeof col.selected.value === 'boolean' || typeof col.selected.value === 'string').toBe(true)
+		}
+	})
+
+	it('selecting column via OSC sets its selected state', async () => {
+		oscApi.send(`/composition/columns/${TEST_COLUMN}/select`, [{ type: 'i', value: 1 }])
+		await pause(300)
+		const col = (await api.Columns.getSettings(TEST_COLUMN)) as any
+		if (col?.selected != null) {
+			expect(col.selected.value === true || col.selected.value === 'Selected').toBe(true)
+		} else {
+			// selected not exposed in REST for this version — verify Resolume is still alive
+			expect(col).toHaveProperty('id')
+		}
+	})
+})

--- a/test/integration/helpers.ts
+++ b/test/integration/helpers.ts
@@ -1,4 +1,4 @@
-import { TEST_HOST, REST_PORT, TEST_LAYER, TEST_COLUMN } from './config'
+import { TEST_HOST, REST_PORT } from './config'
 
 /**
  * Returns true if Resolume's REST API is reachable.
@@ -17,24 +17,6 @@ export async function isResolumeReachable(): Promise<boolean> {
 	}
 }
 
-/**
- * Returns true if the test clip (TEST_LAYER / TEST_COLUMN) has media loaded.
- * 'Empty' means no media; 'Disconnected' or 'Connected' means media is present.
- */
-export async function testClipHasMedia(): Promise<boolean> {
-	try {
-		const { default: fetch } = await import('node-fetch')
-		const res = await fetch(
-			`http://${TEST_HOST}:${REST_PORT}/api/v1/composition/layers/${TEST_LAYER}/clips/${TEST_COLUMN}`,
-			{ timeout: 1500 } as any
-		)
-		if (!res.ok) return false
-		const data = (await res.json()) as any
-		return data?.connected?.value !== 'Empty'
-	} catch {
-		return false
-	}
-}
 
 export function pause(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms))

--- a/test/unit/clip-utils.test.ts
+++ b/test/unit/clip-utils.test.ts
@@ -15,6 +15,7 @@ function makeMockModule() {
 		checkFeedbacks: vi.fn(),
 		checkFeedbacksById: vi.fn(),
 		setVariableValues: vi.fn(),
+		setupVariables: vi.fn(),
 		log: vi.fn(),
 		getWebsocketApi: vi.fn().mockReturnValue(wsApi),
 		getConfig: vi.fn().mockReturnValue({ useCroppedThumbs: false }),
@@ -71,6 +72,133 @@ describe('ClipUtils.messageUpdates — path matching', () => {
 		const cu = new ClipUtils(mod)
 		cu.messageUpdates({ path: '/composition/layers/1/clips/2/select', value: false }, false)
 		expect(mod.setVariableValues).not.toHaveBeenCalled()
+	})
+})
+
+describe('ClipUtils.messageUpdates — clip name variable', () => {
+	it('sets clip_name_l{layer}_c{column} when a name path message arrives', () => {
+		const mod = makeMockModule()
+		const cu = new ClipUtils(mod)
+		cu.messageUpdates({ path: '/composition/layers/2/clips/3/name', value: 'MyClip' }, false)
+		expect(mod.setVariableValues).toHaveBeenCalledWith({ clip_name_l2_c3: 'MyClip' })
+	})
+
+	it('does not call setVariableValues for clip name when path does not match', () => {
+		const mod = makeMockModule()
+		const cu = new ClipUtils(mod)
+		cu.messageUpdates({ path: '/composition/layers/1/clips/1/connect', value: 'Connected' }, false)
+		expect(mod.setVariableValues).not.toHaveBeenCalledWith(expect.objectContaining({ clip_name_l1_c1: expect.anything() }))
+	})
+
+	it('still calls checkFeedbacks("clipInfo") alongside the variable update', () => {
+		const mod = makeMockModule()
+		const cu = new ClipUtils(mod)
+		cu.messageUpdates({ path: '/composition/layers/1/clips/1/name', value: 'Test' }, false)
+		expect(mod.checkFeedbacks).toHaveBeenCalledWith('clipInfo')
+	})
+})
+
+describe('ClipUtils.getClipNameVariableDefinitions', () => {
+	it('returns empty array before composition is loaded', () => {
+		const mod = makeMockModule()
+		const cu = new ClipUtils(mod)
+		expect(cu.getClipNameVariableDefinitions()).toHaveLength(0)
+	})
+
+	it('returns one definition per grid cell after initComposition', () => {
+		const mod = makeMockModule()
+		const cu = new ClipUtils(mod)
+		compositionState.set({
+			layers: [
+				{ clips: [{ name: { value: 'A' } }, { name: { value: 'B' } }] },
+				{ clips: [{ name: { value: 'C' } }, { name: { value: 'D' } }] },
+			]
+		} as any)
+		cu.messageUpdates({ path: '', value: '' }, true)
+		const defs = cu.getClipNameVariableDefinitions()
+		expect(defs).toHaveLength(4)
+		const ids = defs.map((d) => d.variableId)
+		expect(ids).toContain('clip_name_l1_c1')
+		expect(ids).toContain('clip_name_l1_c2')
+		expect(ids).toContain('clip_name_l2_c1')
+		expect(ids).toContain('clip_name_l2_c2')
+	})
+
+	it('handles asymmetric grids — uses max column count across all layers', () => {
+		const mod = makeMockModule()
+		const cu = new ClipUtils(mod)
+		compositionState.set({
+			layers: [
+				{ clips: [{ name: { value: 'A' } }] },
+				{ clips: [{ name: { value: 'B' } }, { name: { value: 'C' } }, { name: { value: 'D' } }] },
+			]
+		} as any)
+		cu.messageUpdates({ path: '', value: '' }, true)
+		const defs = cu.getClipNameVariableDefinitions()
+		// 2 layers × 3 columns (max)
+		expect(defs).toHaveLength(6)
+	})
+})
+
+describe('ClipUtils.initComposition — clip name subscriptions and initial values', () => {
+	it('subscribes to all clip name paths on init', () => {
+		const mod = makeMockModule()
+		const cu = new ClipUtils(mod)
+		compositionState.set({
+			layers: [
+				{ clips: [{ name: { value: 'Clip1' } }, { name: { value: 'Clip2' } }] },
+			]
+		} as any)
+		cu.messageUpdates({ path: '', value: '' }, true)
+		const ws = mod._wsApi
+		expect(ws.subscribePath).toHaveBeenCalledWith('/composition/layers/1/clips/1/name')
+		expect(ws.subscribePath).toHaveBeenCalledWith('/composition/layers/1/clips/2/name')
+	})
+
+	it('sets initial variable values from composition state on init', () => {
+		const mod = makeMockModule()
+		const cu = new ClipUtils(mod)
+		compositionState.set({
+			layers: [
+				{ clips: [{ name: { value: 'Alpha' } }, { name: { value: 'Beta' } }] },
+			]
+		} as any)
+		cu.messageUpdates({ path: '', value: '' }, true)
+		expect(mod.setVariableValues).toHaveBeenCalledWith(
+			expect.objectContaining({ clip_name_l1_c1: 'Alpha', clip_name_l1_c2: 'Beta' })
+		)
+	})
+
+	it('calls setupVariables() to register the dynamic definitions', () => {
+		const mod = makeMockModule()
+		const cu = new ClipUtils(mod)
+		compositionState.set({
+			layers: [{ clips: [{ name: { value: 'X' } }] }]
+		} as any)
+		cu.messageUpdates({ path: '', value: '' }, true)
+		expect(mod.setupVariables).toHaveBeenCalled()
+	})
+
+	it('unsubscribes old paths and resubscribes on composition reload', () => {
+		const mod = makeMockModule()
+		const cu = new ClipUtils(mod)
+		compositionState.set({
+			layers: [{ clips: [{ name: { value: 'Old' } }] }]
+		} as any)
+		cu.messageUpdates({ path: '', value: '' }, true)
+
+		const ws = mod._wsApi
+		ws.subscribePath.mockClear()
+		ws.unsubscribePath.mockClear()
+
+		compositionState.set({
+			layers: [{ clips: [{ name: { value: 'New' } }, { name: { value: 'New2' } }] }]
+		} as any)
+		cu.messageUpdates({ path: '', value: '' }, true)
+
+		expect(ws.unsubscribePath).toHaveBeenCalledWith('/composition/layers/1/clips/1/name')
+		expect(ws.subscribePath).toHaveBeenCalledWith('/composition/layers/1/clips/1/name')
+		expect(ws.subscribePath).toHaveBeenCalledWith('/composition/layers/1/clips/2/name')
 	})
 })
 

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,15 +1,14 @@
+// Integration tests MUST run sequentially (fileParallelism: false).
+// All tests share a single live Resolume Arena instance — parallel file
+// execution causes state stomping (one file's clearAllLayers racing with
+// another file's triggerColumn) that produces spurious failures.
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
 	test: {
 		environment: 'node',
+		fileParallelism: false,
 		include: ['test/integration/**/*.test.ts'],
-		// Integration tests must run serially — one Resolume instance, shared state
-		pool: 'forks',
-		poolOptions: {
-			forks: { singleFork: true },
-		},
-		sequence: { concurrent: false },
-		testTimeout: 10000,
+		testTimeout: 30000,
 	},
 })


### PR DESCRIPTION
## Summary

- Adds `clip_name_l{layer}_c{column}` Companion variables for every cell in the composition grid (e.g. `clip_name_l1_c3`)
- Variables are registered dynamically after the composition loads, so they reflect the actual grid size
- Values update in real-time via websocket `/composition/layers/{n}/clips/{m}/name` messages
- On composition reload, old subscriptions are cleaned up and new ones are created

## Implementation notes

- `ClipUtils.initClipNameVariables()` runs at the end of `initComposition()`: unsubscribes stale paths, subscribes all current clip name paths, populates initial values from `compositionState`, then calls `setupVariables()` to register the dynamic definitions
- `messageUpdates()` now also updates `clip_name_l{n}_c{m}` on name change messages (alongside the existing `checkFeedbacks('clipInfo')`)
- `clipUtils` promoted from `private` to `public` on the module instance so `setupVariables()` can include the dynamic definitions
- Known gap (pre-existing Resolume API limitation): variables do not update when clips are drag-swapped in Resolume

## Test plan

- [x] Unit: `messageUpdates()` sets the correct variable ID and value on name path messages
- [x] Unit: `getClipNameVariableDefinitions()` returns empty before init, correct count after init
- [x] Unit: handles asymmetric grids (max column count across all layers)
- [x] Unit: subscribes to all clip name paths on `initComposition()`
- [x] Unit: populates initial variable values from `compositionState`
- [x] Unit: calls `setupVariables()` to register dynamic definitions
- [x] Unit: unsubscribes old paths and resubscribes on composition reload
- [x] Integration: clip name REST data contract (field exists, is a string)
- [x] Integration: name update roundtrip via REST (write → read back)
- [x] Integration: name update reflected in composition endpoint (the source for initial variable population)
- [x] Integration: every clip in the composition has a name field
- [x] All 349 existing unit tests still pass

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)