### PR TITLE
feat: add Refresh Clip Thumbnail action (#141)

### DIFF
--- a/src/actions/clip/actions/thumbnail-update.ts
+++ b/src/actions/clip/actions/thumbnail-update.ts
@@ -1,25 +1,25 @@
 import {CompanionActionDefinition} from '@companion-module/base';
 import {getClipOption} from '../../../defaults';
-import {WebsocketInstance} from '../../../websocket';
+import {ClipUtils} from '../../../domain/clip/clip-utils';
 import {ResolumeArenaModuleInstance} from '../../../index';
 
 export function thumbnailUpdate(
-	websocketApi: () => (WebsocketInstance | null),
+	clipUtils: () => (ClipUtils | null),
 	resolumeArenaModuleInstance: ResolumeArenaModuleInstance
 ): CompanionActionDefinition {
 	return {
 		name: 'Refresh Clip Thumbnail',
-		description: 'Request Resolume to push the current thumbnail for a clip via WebSocket',
+		description: 'Re-fetch the current thumbnail for a clip from Resolume and update Companion buttons immediately',
 		options: [...getClipOption()],
 		callback: async ({options}: {options: any}): Promise<void> => {
-			const websocket = websocketApi();
-			if (!websocket) {
-				resolumeArenaModuleInstance.log('warn', 'Refresh Clip Thumbnail requires a WebSocket connection (REST mode)');
+			const utils = clipUtils();
+			if (!utils) {
+				resolumeArenaModuleInstance.log('warn', 'Refresh Clip Thumbnail requires a REST connection');
 				return;
 			}
 			const layer = +await resolumeArenaModuleInstance.parseVariablesInString(options.layer);
 			const column = +await resolumeArenaModuleInstance.parseVariablesInString(options.column);
-			websocket.subscribePath(`/composition/layers/${layer}/clips/${column}/thumbnail`);
+			await utils.refreshThumbnail(layer, column);
 		},
 	};
 }

--- a/src/actions/clip/actions/thumbnail-update.ts
+++ b/src/actions/clip/actions/thumbnail-update.ts
@@ -1,0 +1,25 @@
+import {CompanionActionDefinition} from '@companion-module/base';
+import {getClipOption} from '../../../defaults';
+import {WebsocketInstance} from '../../../websocket';
+import {ResolumeArenaModuleInstance} from '../../../index';
+
+export function thumbnailUpdate(
+	websocketApi: () => (WebsocketInstance | null),
+	resolumeArenaModuleInstance: ResolumeArenaModuleInstance
+): CompanionActionDefinition {
+	return {
+		name: 'Refresh Clip Thumbnail',
+		description: 'Request Resolume to push the current thumbnail for a clip via WebSocket',
+		options: [...getClipOption()],
+		callback: async ({options}: {options: any}): Promise<void> => {
+			const websocket = websocketApi();
+			if (!websocket) {
+				resolumeArenaModuleInstance.log('warn', 'Refresh Clip Thumbnail requires a WebSocket connection (REST mode)');
+				return;
+			}
+			const layer = +await resolumeArenaModuleInstance.parseVariablesInString(options.layer);
+			const column = +await resolumeArenaModuleInstance.parseVariablesInString(options.column);
+			websocket.subscribePath(`/composition/layers/${layer}/clips/${column}/thumbnail`);
+		},
+	};
+}

--- a/src/actions/clip/clipActions.ts
+++ b/src/actions/clip/clipActions.ts
@@ -18,6 +18,6 @@ export function getClipActions(resolumeArenaModuleInstance: ResolumeArenaModuleI
 		clipSpeedChange: clipSpeedChange(restApi, websocketApi, oscApi, clipUtils, resolumeArenaModuleInstance),
 		clipOpacityChange: clipOpacityChange(restApi, websocketApi, oscApi, clipUtils, resolumeArenaModuleInstance),
 		clipVolumeChange: clipVolumeChange(restApi, websocketApi, oscApi, clipUtils, resolumeArenaModuleInstance),
-		thumbnailUpdate: thumbnailUpdate(websocketApi, resolumeArenaModuleInstance),
+		thumbnailUpdate: thumbnailUpdate(clipUtils, resolumeArenaModuleInstance),
 	};
 }

--- a/src/actions/clip/clipActions.ts
+++ b/src/actions/clip/clipActions.ts
@@ -5,6 +5,7 @@ import {connectClip} from './actions/connect-clip';
 import {clipSpeedChange} from './actions/clip-speed-change';
 import {clipOpacityChange} from './actions/clip-opacity-change';
 import {clipVolumeChange} from './actions/clip-volume-change';
+import {thumbnailUpdate} from './actions/thumbnail-update';
 
 export function getClipActions(resolumeArenaModuleInstance: ResolumeArenaModuleInstance): CompanionActionDefinitions {
 	const restApi = resolumeArenaModuleInstance.getRestApi.bind(resolumeArenaModuleInstance);
@@ -17,5 +18,6 @@ export function getClipActions(resolumeArenaModuleInstance: ResolumeArenaModuleI
 		clipSpeedChange: clipSpeedChange(restApi, websocketApi, oscApi, clipUtils, resolumeArenaModuleInstance),
 		clipOpacityChange: clipOpacityChange(restApi, websocketApi, oscApi, clipUtils, resolumeArenaModuleInstance),
 		clipVolumeChange: clipVolumeChange(restApi, websocketApi, oscApi, clipUtils, resolumeArenaModuleInstance),
+		thumbnailUpdate: thumbnailUpdate(websocketApi, resolumeArenaModuleInstance),
 	};
 }

--- a/src/domain/clip/clip-utils.ts
+++ b/src/domain/clip/clip-utils.ts
@@ -209,11 +209,14 @@ export class ClipUtils implements MessageSubscriber {
 		const clipId = new ClipId(layer, column);
 		const thumb = await this.resolumeArenaInstance.restApi?.Clips.getThumb(clipId);
 		if (!thumb) return;
-		this.clipBase64Thumbs.set(clipId.getIdString(), thumb);
-		try {
-			this.clipThumbs.set(clipId.getIdString(), drawThumb(thumb));
-		} catch (e) {
-			this.resolumeArenaInstance.log('warn', 'could not draw thumb: ' + e);
+		if (this.resolumeArenaInstance.getConfig().useCroppedThumbs) {
+			try {
+				this.clipThumbs.set(clipId.getIdString(), drawThumb(thumb));
+			} catch (e) {
+				this.resolumeArenaInstance.log('warn', 'could not draw thumb: ' + e);
+			}
+		} else {
+			this.clipBase64Thumbs.set(clipId.getIdString(), thumb);
 		}
 		this.resolumeArenaInstance.checkFeedbacks('clipInfo');
 	}

--- a/src/domain/clip/clip-utils.ts
+++ b/src/domain/clip/clip-utils.ts
@@ -205,6 +205,19 @@ export class ClipUtils implements MessageSubscriber {
 
 	}
 
+	async refreshThumbnail(layer: number, column: number): Promise<void> {
+		const clipId = new ClipId(layer, column);
+		const thumb = await this.resolumeArenaInstance.restApi?.Clips.getThumb(clipId);
+		if (!thumb) return;
+		this.clipBase64Thumbs.set(clipId.getIdString(), thumb);
+		try {
+			this.clipThumbs.set(clipId.getIdString(), drawThumb(thumb));
+		} catch (e) {
+			this.resolumeArenaInstance.log('warn', 'could not draw thumb: ' + e);
+		}
+		this.resolumeArenaInstance.checkFeedbacks('clipInfo');
+	}
+
 	async getThumbs(clipId: ClipId, feedbackId: string) {
 		let thumb = await this.resolumeArenaInstance.restApi?.Clips.getThumb(clipId);
 		if (thumb) {

--- a/test/integration/clip-thumbnail.test.ts
+++ b/test/integration/clip-thumbnail.test.ts
@@ -2,10 +2,12 @@
  * Clip thumbnail and clear integration tests:
  * - Clips.getThumb() returns base64 image data for a clip with media
  * - Clips.clear() disconnects a connected clip via REST
+ * - ClipUtils.refreshThumbnail() fetches and caches the thumbnail
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import ArenaRestApi from '../../src/arena-api/rest'
 import { ClipId } from '../../src/domain/clip/clip-id'
+import { ClipUtils } from '../../src/domain/clip/clip-utils'
 import { TEST_HOST, REST_PORT, TEST_LAYER, TEST_COLUMN } from './config'
 import { isResolumeReachable, pause } from './helpers'
 
@@ -52,4 +54,48 @@ describe.skipIf(!resolume)('REST read — clip thumbnail for empty clip', () => 
 	})
 })
 
+// ── ClipUtils.refreshThumbnail ────────────────────────────────────────────────
 
+describe.skipIf(!resolume)('ClipUtils.refreshThumbnail (requires media)', () => {
+	let clipUtils: ClipUtils
+
+	beforeAll(async () => {
+		await api.Clips.connect(new ClipId(TEST_LAYER, TEST_COLUMN))
+		await pause(400)
+
+		const shim: any = {
+			log: () => {},
+			checkFeedbacks: () => {},
+			checkFeedbacksById: () => {},
+			setVariableValues: () => {},
+			getConfig: () => ({ useCroppedThumbs: false }),
+			getWebsocketApi: () => null,
+			getClipUtils: () => clipUtils,
+			restApi: api,
+		}
+		clipUtils = new ClipUtils(shim)
+	})
+
+	afterAll(async () => {
+		await api.Layers.clear(TEST_LAYER)
+		await pause(300)
+	})
+
+	it('refreshThumbnail populates the base64 thumbnail cache for a connected clip', async () => {
+		await clipUtils.refreshThumbnail(TEST_LAYER, TEST_COLUMN)
+		const clipId = new ClipId(TEST_LAYER, TEST_COLUMN)
+		// Access internal cache via any cast — integration test only
+		const cache = (clipUtils as any).clipBase64Thumbs as Map<string, string>
+		const thumb = cache.get(clipId.getIdString())
+		expect(typeof thumb).toBe('string')
+		expect(thumb!.length).toBeGreaterThan(0)
+	})
+
+	it('calling refreshThumbnail twice does not throw and updates the cache', async () => {
+		await clipUtils.refreshThumbnail(TEST_LAYER, TEST_COLUMN)
+		await clipUtils.refreshThumbnail(TEST_LAYER, TEST_COLUMN)
+		const clipId = new ClipId(TEST_LAYER, TEST_COLUMN)
+		const cache = (clipUtils as any).clipBase64Thumbs as Map<string, string>
+		expect(cache.has(clipId.getIdString())).toBe(true)
+	})
+})

--- a/test/unit/thumbnail-update-action.test.ts
+++ b/test/unit/thumbnail-update-action.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest'
+import { thumbnailUpdate } from '../../src/actions/clip/actions/thumbnail-update'
+
+function makeWebsocketApi() {
+	return { subscribePath: vi.fn() }
+}
+
+function makeInstance(parseResult = '1') {
+	return {
+		log: vi.fn(),
+		parseVariablesInString: vi.fn().mockResolvedValue(parseResult),
+	} as any
+}
+
+describe('thumbnailUpdate action definition', () => {
+	it('has the correct action name', () => {
+		const action = thumbnailUpdate(() => null, makeInstance())
+		expect(action.name).toBe('Refresh Clip Thumbnail')
+	})
+
+	it('has two options (layer and column)', () => {
+		const action = thumbnailUpdate(() => null, makeInstance())
+		expect(action.options).toHaveLength(2)
+		const ids = action.options.map((o: any) => o.id)
+		expect(ids).toContain('layer')
+		expect(ids).toContain('column')
+	})
+})
+
+describe('thumbnailUpdate callback — WebSocket available', () => {
+	it('calls subscribePath with the correct clip thumbnail path', async () => {
+		const ws = makeWebsocketApi()
+		let callIndex = 0
+		const instance = {
+			log: vi.fn(),
+			parseVariablesInString: vi.fn().mockImplementation(() =>
+				Promise.resolve(callIndex++ === 0 ? '2' : '3')
+			),
+		} as any
+		const action = thumbnailUpdate(() => ws as any, instance)
+		await (action.callback as any)({ options: { layer: '2', column: '3' } })
+		expect(ws.subscribePath).toHaveBeenCalledWith('/composition/layers/2/clips/3/thumbnail')
+	})
+
+	it('uses parsed variable values for layer and column', async () => {
+		const ws = makeWebsocketApi()
+		let callIndex = 0
+		const instance = {
+			log: vi.fn(),
+			parseVariablesInString: vi.fn().mockImplementation(() =>
+				Promise.resolve(callIndex++ === 0 ? '5' : '1')
+			),
+		} as any
+		const action = thumbnailUpdate(() => ws as any, instance)
+		await (action.callback as any)({ options: { layer: '$(var:layer)', column: '1' } })
+		expect(ws.subscribePath).toHaveBeenCalledWith('/composition/layers/5/clips/1/thumbnail')
+	})
+})
+
+describe('thumbnailUpdate callback — no WebSocket (OSC-only mode)', () => {
+	it('logs a warning and does not throw', async () => {
+		const instance = makeInstance('1')
+		const action = thumbnailUpdate(() => null, instance)
+		await (action.callback as any)({ options: { layer: '1', column: '1' } })
+		expect(instance.log).toHaveBeenCalledWith('warn', expect.any(String))
+	})
+
+	it('does not call subscribePath when websocket is null', async () => {
+		const ws = makeWebsocketApi()
+		const instance = makeInstance('1')
+		const action = thumbnailUpdate(() => null, instance)
+		await (action.callback as any)({ options: { layer: '1', column: '1' } })
+		expect(ws.subscribePath).not.toHaveBeenCalled()
+	})
+})

--- a/test/unit/thumbnail-update-action.test.ts
+++ b/test/unit/thumbnail-update-action.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
 import { thumbnailUpdate } from '../../src/actions/clip/actions/thumbnail-update'
 
-function makeWebsocketApi() {
-	return { subscribePath: vi.fn() }
+function makeClipUtils() {
+	return { refreshThumbnail: vi.fn().mockResolvedValue(undefined) }
 }
 
 function makeInstance(parseResult = '1') {
@@ -27,9 +27,9 @@ describe('thumbnailUpdate action definition', () => {
 	})
 })
 
-describe('thumbnailUpdate callback — WebSocket available', () => {
-	it('calls subscribePath with the correct clip thumbnail path', async () => {
-		const ws = makeWebsocketApi()
+describe('thumbnailUpdate callback — REST available', () => {
+	it('calls refreshThumbnail with the correct layer and column', async () => {
+		const utils = makeClipUtils()
 		let callIndex = 0
 		const instance = {
 			log: vi.fn(),
@@ -37,13 +37,13 @@ describe('thumbnailUpdate callback — WebSocket available', () => {
 				Promise.resolve(callIndex++ === 0 ? '2' : '3')
 			),
 		} as any
-		const action = thumbnailUpdate(() => ws as any, instance)
+		const action = thumbnailUpdate(() => utils as any, instance)
 		await (action.callback as any)({ options: { layer: '2', column: '3' } })
-		expect(ws.subscribePath).toHaveBeenCalledWith('/composition/layers/2/clips/3/thumbnail')
+		expect(utils.refreshThumbnail).toHaveBeenCalledWith(2, 3)
 	})
 
 	it('uses parsed variable values for layer and column', async () => {
-		const ws = makeWebsocketApi()
+		const utils = makeClipUtils()
 		let callIndex = 0
 		const instance = {
 			log: vi.fn(),
@@ -51,13 +51,13 @@ describe('thumbnailUpdate callback — WebSocket available', () => {
 				Promise.resolve(callIndex++ === 0 ? '5' : '1')
 			),
 		} as any
-		const action = thumbnailUpdate(() => ws as any, instance)
+		const action = thumbnailUpdate(() => utils as any, instance)
 		await (action.callback as any)({ options: { layer: '$(var:layer)', column: '1' } })
-		expect(ws.subscribePath).toHaveBeenCalledWith('/composition/layers/5/clips/1/thumbnail')
+		expect(utils.refreshThumbnail).toHaveBeenCalledWith(5, 1)
 	})
 })
 
-describe('thumbnailUpdate callback — no WebSocket (OSC-only mode)', () => {
+describe('thumbnailUpdate callback — no ClipUtils (OSC-only mode)', () => {
 	it('logs a warning and does not throw', async () => {
 		const instance = makeInstance('1')
 		const action = thumbnailUpdate(() => null, instance)
@@ -65,11 +65,11 @@ describe('thumbnailUpdate callback — no WebSocket (OSC-only mode)', () => {
 		expect(instance.log).toHaveBeenCalledWith('warn', expect.any(String))
 	})
 
-	it('does not call subscribePath when websocket is null', async () => {
-		const ws = makeWebsocketApi()
+	it('does not call refreshThumbnail when clipUtils is null', async () => {
+		const utils = makeClipUtils()
 		const instance = makeInstance('1')
 		const action = thumbnailUpdate(() => null, instance)
 		await (action.callback as any)({ options: { layer: '1', column: '1' } })
-		expect(ws.subscribePath).not.toHaveBeenCalled()
+		expect(utils.refreshThumbnail).not.toHaveBeenCalled()
 	})
 })


### PR DESCRIPTION
## Summary

- Adds a **Refresh Clip Thumbnail** action that re-fetches the current thumbnail for a clip from Resolume via REST and immediately updates Companion buttons
- Implemented via `ClipUtils.refreshThumbnail()` which calls `Clips.getThumb()` and populates the correct cache (`clipBase64Thumbs` or `clipThumbs`) based on the `useCroppedThumbs` config
- Gracefully logs a warning when used in OSC-only mode (no REST connection)

## Test plan

- [x] Unit tests: action definition shape, layer/column parsing, variable substitution, OSC-only warning
- [x] Integration tests: `getThumb` returns valid base64 for a connected clip, empty clip does not throw, `refreshThumbnail` populates the cache, double-call is idempotent

Closes #141