### PR TITLE
fix: populate previewedClipName variable (#142)

### DIFF
--- a/src/domain/clip/clip-utils.ts
+++ b/src/domain/clip/clip-utils.ts
@@ -529,11 +529,15 @@ export class ClipUtils implements MessageSubscriber {
 	}
 
 	clipConnectedWebsocketSubscribe(layer: number, column: number) {
-		this.resolumeArenaInstance.getWebsocketApi()?.subscribePath('/composition/layers/' + layer + '/clips/' + column + '/connect');
+		const ws = this.resolumeArenaInstance.getWebsocketApi();
+		ws?.subscribePath('/composition/layers/' + layer + '/clips/' + column + '/connect');
+		ws?.subscribePath('/composition/layers/' + layer + '/clips/' + column + '/name');
 	}
 
 	clipConnectedWebsocketUnsubscribe(layer: number, column: number) {
-		this.resolumeArenaInstance.getWebsocketApi()?.unsubscribePath('/composition/layers/' + layer + '/clips/' + column + '/connect');
+		const ws = this.resolumeArenaInstance.getWebsocketApi();
+		ws?.unsubscribePath('/composition/layers/' + layer + '/clips/' + column + '/connect');
+		ws?.unsubscribePath('/composition/layers/' + layer + '/clips/' + column + '/name');
 	}
 
 	/////////////////////////////////////////////////

--- a/test/integration/previewed-clip-name.test.ts
+++ b/test/integration/previewed-clip-name.test.ts
@@ -1,0 +1,99 @@
+/**
+ * previewedClipName variable data-pipeline tests (issue #142).
+ *
+ * The variable is populated inside clipConnectedFeedbackCallback, which reads
+ * the clip name from parameterStates. The fix (co-subscribing /name alongside
+ * /connect) ensures the name is available regardless of whether a separate
+ * clipDetails feedback is configured.
+ *
+ * These tests verify the REST data contract that drives the variable:
+ * - The /connect field exists and returns the expected string values
+ * - The /name field is readable alongside /connect in the same clip object
+ * - When a clip is connected, both fields are non-empty
+ *
+ * We cannot assert the Companion variable value directly (requires a live
+ * module instance), so we validate the underlying API surface.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import ArenaRestApi from '../../src/arena-api/rest'
+import { ClipId } from '../../src/domain/clip/clip-id'
+import { TEST_HOST, REST_PORT, TEST_LAYER, TEST_COLUMN } from './config'
+import { isResolumeReachable, pause } from './helpers'
+
+const resolume = await isResolumeReachable()
+
+const api = new ArenaRestApi(TEST_HOST, REST_PORT)
+const clipUrl = `http://${TEST_HOST}:${REST_PORT}/api/v1/composition/layers/${TEST_LAYER}/clips/${TEST_COLUMN}`
+
+async function fetchClip(): Promise<any> {
+	const { default: fetch } = await import('node-fetch')
+	const res = await fetch(clipUrl, { timeout: 3000 } as any)
+	return res.json()
+}
+
+// ── connect field data contract ───────────────────────────────────────────────
+
+describe.skipIf(!resolume)('previewedClipName — connect field data contract', () => {
+	it('clip at TEST_LAYER/TEST_COLUMN has a connect field', async () => {
+		const clip = await fetchClip()
+		expect(clip).toHaveProperty('connected')
+	})
+
+	it('connect field has a string value property', async () => {
+		const clip = await fetchClip()
+		expect(typeof clip?.connected?.value).toBe('string')
+	})
+
+	it('connect field options include "Previewing" and "Connected & previewing"', async () => {
+		const clip = await fetchClip()
+		const options: string[] = clip?.connected?.options ?? []
+		expect(options).toContain('Previewing')
+		expect(options).toContain('Connected & previewing')
+	})
+})
+
+// ── name and connect co-presence ─────────────────────────────────────────────
+
+describe.skipIf(!resolume)('previewedClipName — name available alongside connect', () => {
+	it('clip REST response contains both connected and name fields', async () => {
+		const clip = await fetchClip()
+		expect(clip).toHaveProperty('connected')
+		expect(clip).toHaveProperty('name')
+	})
+
+	it('name.value is a string (not undefined) when clip is idle', async () => {
+		const clip = await fetchClip()
+		expect(typeof clip?.name?.value).toBe('string')
+	})
+})
+
+// ── name present while clip is connected ─────────────────────────────────────
+
+describe.skipIf(!resolume)('previewedClipName — name readable while clip is connected', () => {
+	beforeAll(async () => {
+		await api.Clips.connect(new ClipId(TEST_LAYER, TEST_COLUMN))
+		await pause(400)
+	})
+
+	afterAll(async () => {
+		await api.Layers.clear(TEST_LAYER)
+		await pause(300)
+	})
+
+	it('connect value is "Connected" after connecting the clip', async () => {
+		const clip = await fetchClip()
+		expect(clip?.connected?.value).toBe('Connected')
+	})
+
+	it('name.value is a non-empty string while the clip is connected', async () => {
+		const clip = await fetchClip()
+		expect(typeof clip?.name?.value).toBe('string')
+		expect((clip?.name?.value as string).length).toBeGreaterThan(0)
+	})
+
+	it('both name and connected are present in the same REST response', async () => {
+		const clip = await fetchClip()
+		expect(clip?.connected?.value).toBeDefined()
+		expect(clip?.name?.value).toBeDefined()
+	})
+})

--- a/test/unit/clip-utils.test.ts
+++ b/test/unit/clip-utils.test.ts
@@ -202,6 +202,75 @@ describe('ClipUtils.initComposition — clip name subscriptions and initial valu
 	})
 })
 
+describe('ClipUtils.clipConnectedWebsocketSubscribe / Unsubscribe', () => {
+	it('subscribes to both connect and name paths', () => {
+		const mod = makeMockModule()
+		const cu = new ClipUtils(mod)
+		cu.clipConnectedWebsocketSubscribe(2, 3)
+		const ws = mod._wsApi
+		expect(ws.subscribePath).toHaveBeenCalledWith('/composition/layers/2/clips/3/connect')
+		expect(ws.subscribePath).toHaveBeenCalledWith('/composition/layers/2/clips/3/name')
+	})
+
+	it('unsubscribes from both connect and name paths', () => {
+		const mod = makeMockModule()
+		const cu = new ClipUtils(mod)
+		cu.clipConnectedWebsocketUnsubscribe(2, 3)
+		const ws = mod._wsApi
+		expect(ws.unsubscribePath).toHaveBeenCalledWith('/composition/layers/2/clips/3/connect')
+		expect(ws.unsubscribePath).toHaveBeenCalledWith('/composition/layers/2/clips/3/name')
+	})
+})
+
+describe('ClipUtils.clipConnectedFeedbackCallback — previewedClipName', () => {
+	function makeConnectedFeedback(layer: string, column: string, id = 'fb1') {
+		return {
+			id,
+			options: {
+				layer,
+				column,
+				color_connected: 0,
+				color_connected_selected: 0,
+				color_connected_preview: 0,
+				color_preview: 0,
+			},
+		} as any
+	}
+
+	it('sets previewedClipName when clip is Previewing and name is in parameterStates', async () => {
+		const mod = makeMockModule()
+		const cu = new ClipUtils(mod)
+		parameterStates.set({
+			'/composition/layers/1/clips/2/connect': { value: 'Previewing' },
+			'/composition/layers/1/clips/2/name': { value: 'MyAwesomeClip' },
+		} as any)
+		await cu.clipConnectedFeedbackCallback(makeConnectedFeedback('1', '2'), makeContext('1', '2'))
+		expect(mod.setVariableValues).toHaveBeenCalledWith({ previewedClipName: 'MyAwesomeClip' })
+	})
+
+	it('sets previewedClipName when clip is Connected & previewing', async () => {
+		const mod = makeMockModule()
+		const cu = new ClipUtils(mod)
+		parameterStates.set({
+			'/composition/layers/3/clips/4/connect': { value: 'Connected & previewing' },
+			'/composition/layers/3/clips/4/name': { value: 'OtherClip' },
+		} as any)
+		await cu.clipConnectedFeedbackCallback(makeConnectedFeedback('3', '4'), makeContext('3', '4'))
+		expect(mod.setVariableValues).toHaveBeenCalledWith({ previewedClipName: 'OtherClip' })
+	})
+
+	it('does not set previewedClipName when clip is only Connected (no preview)', async () => {
+		const mod = makeMockModule()
+		const cu = new ClipUtils(mod)
+		parameterStates.set({
+			'/composition/layers/1/clips/1/connect': { value: 'Connected' },
+			'/composition/layers/1/clips/1/name': { value: 'SomeClip' },
+		} as any)
+		await cu.clipConnectedFeedbackCallback(makeConnectedFeedback('1', '1'), makeContext('1', '1'))
+		expect(mod.setVariableValues).not.toHaveBeenCalledWith({ previewedClipName: expect.anything() })
+	})
+})
+
 describe('ClipUtils.clipSelectedFeedbackCallback', () => {
 	it('returns true when parameterStates has select = true for the clip', async () => {
 		const mod = makeMockModule()


### PR DESCRIPTION
## Summary

- `previewedClipName` (and `previewedClip`, `previewedClipLayer`, `previewedClipColumn`) was always empty/undefined because `clipConnectedFeedbackCallback` reads the clip name from `parameterStates`, but the `/name` WebSocket path was only subscribed when a separate **clipDetails** feedback existed for that exact layer/column slot
- Fix: co-subscribe `/name` alongside `/connect` in `clipConnectedWebsocketSubscribe` and co-unsubscribe in `clipConnectedWebsocketUnsubscribe` — so the name is always in `parameterStates` whenever the connected feedback fires

## Test plan

- [ ] Unit tests: `ClipUtils.clipConnectedWebsocketSubscribe / Unsubscribe` — verifies both paths are subscribed/unsubscribed
- [ ] Unit tests: `ClipUtils.clipConnectedFeedbackCallback — previewedClipName` — verifies the variable is set for "Previewing" and "Connected & previewing" states, and not set for plain "Connected"
- [ ] Integration tests: `previewed-clip-name.test.ts` — verifies the REST data contract (`connected` and `name` co-presence, string enum options, non-empty name while connected)
- [ ] Manual: configure a Companion button with only a `connectedClip` feedback (no `clipDetails` feedback) — preview a clip in Resolume — confirm `$(custom_variable:previewedClipName)` is populated

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)