### PR TITLE
chore: run tsc build in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 sed -e '/INSERT_HELP/{r ./companion/HELP.md' -e 'd' -e '}' README.tpl > README.md
+yarn build

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+yarn build

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,0 @@
-yarn build


### PR DESCRIPTION
## Summary

- Adds `yarn build` to the pre-commit hook so TypeScript type errors are caught locally before they reach CI.
- Prevents the kind of `TS18048` failure that slipped through on PR #169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)