### PR TITLE
fix: re-evaluate bypass feedback for single subscriber (#134)

### DIFF
--- a/src/actions/layer/actions/bypass-layer.ts
+++ b/src/actions/layer/actions/bypass-layer.ts
@@ -43,7 +43,7 @@ export function bypassLayer(
 			let thewebsocketApi = websocketApi();
 			const layer = +await resolumeArenaInstance.parseVariablesInString(options.layer);
 			if (theApi) {
-				let bypassed;
+				let bypassed: boolean;
 				if (options.bypass == 'toggle') {
 					bypassed = !parameterStates.get()['/composition/layers/' + layer + '/bypassed']?.value;
 				} else {

--- a/src/actions/layer/actions/bypass-layer.ts
+++ b/src/actions/layer/actions/bypass-layer.ts
@@ -50,6 +50,15 @@ export function bypassLayer(
 					bypassed = options.bypass == 'on';
 				}
 				thewebsocketApi?.setPath(`/composition/layers/${layer}/bypassed`, bypassed);
+				// Optimistically update local state so the feedback re-evaluates immediately,
+				// even if the WS subscription was briefly dropped (e.g. single-subscriber
+				// rotary encoder unsubscribe/subscribe cycle) and the parameter_update from
+				// Resolume is not yet received or is silently lost.
+				const bypassedPath = '/composition/layers/' + layer + '/bypassed';
+				parameterStates.update((state) => {
+					state[bypassedPath] = {value: bypassed} as any;
+				});
+				resolumeArenaInstance.checkFeedbacks('layerBypassed');
 			} else {
 				let bypassed;
 				switch (options.bypass) {

--- a/test/unit/layer-actions.test.ts
+++ b/test/unit/layer-actions.test.ts
@@ -24,6 +24,7 @@ function makeInstance(parseResults: string[] | string = '1') {
 	let callIndex = 0
 	return {
 		log: vi.fn(),
+		checkFeedbacks: vi.fn(),
 		parseVariablesInString: vi.fn().mockImplementation(() => {
 			if (results) {
 				return Promise.resolve(results[callIndex++] ?? results[results.length - 1])
@@ -75,6 +76,58 @@ describe('bypassLayer — REST path', () => {
 		const action = bypassLayer(() => ({} as any), () => ws as any, () => null, instance)
 		await (action.callback as any)({ options: { layer: '1', bypass: 'toggle' } })
 		expect(ws.setPath).toHaveBeenCalledWith('/composition/layers/1/bypassed', false)
+	})
+})
+
+describe('bypassLayer — optimistic state update and checkFeedbacks', () => {
+	it('bypass=on updates parameterStates immediately and calls checkFeedbacks', async () => {
+		const ws = makeWsApi()
+		const instance = makeInstance('1')
+		const action = bypassLayer(() => ({} as any), () => ws as any, () => null, instance)
+		await (action.callback as any)({ options: { layer: '1', bypass: 'on' } })
+		expect(parameterStates.get()['/composition/layers/1/bypassed']?.value).toBe(true)
+		expect(instance.checkFeedbacks).toHaveBeenCalledWith('layerBypassed')
+	})
+
+	it('bypass=off updates parameterStates immediately to false', async () => {
+		const ws = makeWsApi()
+		parameterStates.set({ '/composition/layers/1/bypassed': { value: true } } as any)
+		const instance = makeInstance('1')
+		const action = bypassLayer(() => ({} as any), () => ws as any, () => null, instance)
+		await (action.callback as any)({ options: { layer: '1', bypass: 'off' } })
+		expect(parameterStates.get()['/composition/layers/1/bypassed']?.value).toBe(false)
+		expect(instance.checkFeedbacks).toHaveBeenCalledWith('layerBypassed')
+	})
+
+	it('bypass=toggle updates parameterStates to flipped value immediately', async () => {
+		const ws = makeWsApi()
+		parameterStates.set({ '/composition/layers/1/bypassed': { value: false } } as any)
+		const instance = makeInstance('1')
+		const action = bypassLayer(() => ({} as any), () => ws as any, () => null, instance)
+		await (action.callback as any)({ options: { layer: '1', bypass: 'toggle' } })
+		expect(parameterStates.get()['/composition/layers/1/bypassed']?.value).toBe(true)
+		expect(instance.checkFeedbacks).toHaveBeenCalledWith('layerBypassed')
+	})
+
+	it('single subscriber: feedback re-evaluates even when WS subscription is temporarily dropped', async () => {
+		// Simulates the single-rotary-encoder scenario: only one feedback subscriber,
+		// bypass is toggled, parameterStates is updated optimistically, checkFeedbacks fires.
+		const ws = makeWsApi()
+		parameterStates.set({ '/composition/layers/2/bypassed': { value: true } } as any)
+		const instance = makeInstance('2')
+		const action = bypassLayer(() => ({} as any), () => ws as any, () => null, instance)
+		await (action.callback as any)({ options: { layer: '2', bypass: 'toggle' } })
+		// State should reflect the new bypassed=false immediately, without needing a WS response
+		expect(parameterStates.get()['/composition/layers/2/bypassed']?.value).toBe(false)
+		expect(instance.checkFeedbacks).toHaveBeenCalledWith('layerBypassed')
+	})
+
+	it('does not call checkFeedbacks when restApi is null (OSC path)', async () => {
+		const osc = makeOscApi()
+		const instance = makeInstance('1')
+		const action = bypassLayer(() => null, () => null, () => osc as any, instance)
+		await (action.callback as any)({ options: { layer: '1', bypass: 'on' } })
+		expect(instance.checkFeedbacks).not.toHaveBeenCalled()
 	})
 })
 


### PR DESCRIPTION
## Summary

- When a rotary encoder is the **only** subscriber for a layer's `bypassed` path, Companion's subscribe/unsubscribe cycle briefly drops the WS subscription during the action press, so the `parameter_update` from Resolume never arrives and the feedback stays stale.
- Fix: immediately write the new `bypassed` value into `parameterStates` and call `checkFeedbacks('layerBypassed')` after `setPath`, so the feedback re-evaluates without waiting for a WS response.

## Test plan

- [x] `bypass=on` updates `parameterStates` immediately and calls `checkFeedbacks`
- [x] `bypass=off` updates `parameterStates` immediately to `false`
- [x] `bypass=toggle` flips the current value in `parameterStates` immediately
- [x] Single-subscriber scenario: feedback re-evaluates even when WS subscription is temporarily dropped
- [x] OSC path: `checkFeedbacks` is **not** called (optimistic update only applies to WS path)
- [x] All 415 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)