### PR TITLE
feat: add Disconnect All Clips action (#52)

### DIFF
--- a/src/actions/composition/actions/disconnect-all.ts
+++ b/src/actions/composition/actions/disconnect-all.ts
@@ -1,0 +1,22 @@
+import {CompanionActionDefinition} from '@companion-module/base';
+import ArenaOscApi from '../../../arena-api/osc';
+import ArenaRestApi from '../../../arena-api/rest';
+import {WebsocketInstance} from '../../../websocket';
+
+export function disconnectAll(
+	restApi: () => ArenaRestApi | null,
+	websocketApi: () => WebsocketInstance | null,
+	oscApi: () => ArenaOscApi | null
+): CompanionActionDefinition {
+	return {
+		name: 'Disconnect All Clips',
+		options: [],
+		callback: async () => {
+			if (restApi()) {
+				websocketApi()?.triggerPath('/composition/disconnect-all');
+			} else {
+				oscApi()?.clearAllLayers();
+			}
+		},
+	};
+}

--- a/src/actions/composition/compositionActions.ts
+++ b/src/actions/composition/compositionActions.ts
@@ -1,6 +1,7 @@
 import {CompanionActionDefinitions} from '@companion-module/base';
 import {ResolumeArenaModuleInstance} from '../../index';
 import {clearAllLayers} from './actions/clear-all-layers';
+import {disconnectAll} from './actions/disconnect-all';
 import {tempoTap} from './actions/tempo-tap';
 import {tempoResync} from './actions/tempo-resync';
 import {compositionMasterChange} from './actions/composition-master-change';
@@ -14,6 +15,7 @@ export function getCompositionActions(resolumeArenaModuleInstance: ResolumeArena
 	const oscApi = resolumeArenaModuleInstance.getOscApi.bind(resolumeArenaModuleInstance);
 	return {
 		clearAll: clearAllLayers(restApi, websocketApi, oscApi),
+		disconnectAll: disconnectAll(restApi, websocketApi, oscApi),
 		tempoTap: tempoTap(restApi, websocketApi, oscApi),
 		resyncTap: tempoResync(restApi, websocketApi, oscApi),
 		compositionMasterChange: compositionMasterChange(restApi, websocketApi, oscApi, resolumeArenaModuleInstance),

--- a/test/integration/disconnect-all.test.ts
+++ b/test/integration/disconnect-all.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Integration test for the Disconnect All Clips action (#52).
+ *
+ * Validates that /composition/disconnect-all via WebSocket actually
+ * disconnects a connected clip in Resolume.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import ArenaRestApi from '../../src/arena-api/rest'
+import { WebsocketInstance } from '../../src/websocket'
+import { ClipId } from '../../src/domain/clip/clip-id'
+import { TEST_HOST, REST_PORT, TEST_LAYER, TEST_COLUMN } from './config'
+import { isResolumeReachable, pause } from './helpers'
+
+const resolume = await isResolumeReachable()
+
+const api = new ArenaRestApi(TEST_HOST, REST_PORT)
+
+const mockResolumeInstance: any = {
+	log: () => {},
+	updateStatus: () => {},
+	getWebSocketSubscribers: () => new Set(),
+	restartApis: async () => {},
+}
+
+const mockConfig: any = {
+	host: TEST_HOST,
+	webapiPort: REST_PORT,
+	useSSL: false,
+}
+
+let ws: WebsocketInstance
+
+beforeAll(async () => {
+	if (!resolume) return
+	ws = new WebsocketInstance(mockResolumeInstance, mockConfig)
+	await ws.waitForWebsocketReady()
+})
+
+afterAll(async () => {
+	if (ws) await ws.destroy()
+	// Leave composition clean
+	if (resolume) await api.Layers.clear(TEST_LAYER).catch(() => {})
+})
+
+describe.skipIf(!resolume)('disconnectAll action — /composition/disconnect-all', () => {
+	it('disconnects a connected clip via WebSocket trigger', async () => {
+		// Connect a clip first
+		await api.Clips.connect(new ClipId(TEST_LAYER, TEST_COLUMN))
+		await pause(400)
+
+		const before = await api.Clips.getStatus(new ClipId(TEST_LAYER, TEST_COLUMN)) as any
+		expect(before?.connected?.value).toMatch(/Connected/)
+
+		// Trigger disconnect-all via WebSocket
+		await ws.triggerPath('/composition/disconnect-all')
+		await pause(400)
+
+		const after = await api.Clips.getStatus(new ClipId(TEST_LAYER, TEST_COLUMN)) as any
+		expect(after?.connected?.value).not.toMatch(/^Connected$/)
+	})
+})

--- a/test/unit/disconnect-all.test.ts
+++ b/test/unit/disconnect-all.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest'
+import { disconnectAll } from '../../src/actions/composition/actions/disconnect-all'
+
+describe('disconnectAll — REST path', () => {
+	it('triggers /composition/disconnect-all via websocket', async () => {
+		const ws = { triggerPath: vi.fn() }
+		const action = disconnectAll(() => ({} as any), () => ws as any, () => null)
+		await (action.callback as any)({ options: {} })
+		expect(ws.triggerPath).toHaveBeenCalledWith('/composition/disconnect-all')
+	})
+})
+
+describe('disconnectAll — OSC path', () => {
+	it('calls oscApi.clearAllLayers when REST api is unavailable', async () => {
+		const osc = { clearAllLayers: vi.fn() }
+		const action = disconnectAll(() => null, () => null, () => osc as any)
+		await (action.callback as any)({ options: {} })
+		expect(osc.clearAllLayers).toHaveBeenCalled()
+	})
+
+	it('does not call oscApi when REST api is available', async () => {
+		const osc = { clearAllLayers: vi.fn() }
+		const ws = { triggerPath: vi.fn() }
+		const action = disconnectAll(() => ({} as any), () => ws as any, () => osc as any)
+		await (action.callback as any)({ options: {} })
+		expect(osc.clearAllLayers).not.toHaveBeenCalled()
+	})
+})


### PR DESCRIPTION
## Summary

Closes #52.

The REST API exposes `/composition/disconnect-all` but the module had no action for it — only the OSC-based `clearAll` which iterates each layer individually. This adds a dedicated `Disconnect All Clips` action that uses the single REST endpoint when available, and falls back to the OSC path in OSC-only mode.

- New action key: `disconnectAll`
- REST/WS path: `websocketApi.triggerPath('/composition/disconnect-all')`
- OSC fallback: `oscApi.clearAllLayers()`

## Test plan

- [x] `yarn test` — 439 unit tests pass
- [x] `yarn test:integration` — 231 integration tests pass
- [x] Unit: REST path triggers WS, OSC path triggers osc, REST present → OSC not called
- [x] Integration: connects a clip, triggers disconnect-all, verifies clip is no longer Connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)