### PR TITLE
fix: upgrade @julusian/image-rs to ^1.1.1 — removes vcruntime dependency on Windows (#179)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	},
 	"dependencies": {
 		"@companion-module/base": "~1.10.0",
-		"@julusian/image-rs": "^0.2.1",
+		"@julusian/image-rs": "^1.1.1",
 		"@persevie/statemanjs": "^1.6.0",
 		"companion-module-utils": "^0.4.0",
 		"node-fetch": "^2.0.0",

--- a/src/image-utils.ts
+++ b/src/image-utils.ts
@@ -36,7 +36,7 @@ export function drawThumb(thumb: string): Uint8Array {
 		.scale(64, 64, ResizeMode.Fill)
 		.toBufferSync(PixelFormat.Rgb);
 
-	return new Uint8Array(out.buffer);
+	return out.buffer as Uint8Array;
 }
 
 function createColorBlock(fillColor: number, percentage: number = 0) {

--- a/src/image-utils.ts
+++ b/src/image-utils.ts
@@ -36,7 +36,7 @@ export function drawThumb(thumb: string): Uint8Array {
 		.scale(64, 64, ResizeMode.Fill)
 		.toBufferSync(PixelFormat.Rgb);
 
-	return out;
+	return new Uint8Array(out.buffer);
 }
 
 function createColorBlock(fillColor: number, percentage: number = 0) {

--- a/test/integration/clip-thumbnail.test.ts
+++ b/test/integration/clip-thumbnail.test.ts
@@ -2,12 +2,15 @@
  * Clip thumbnail and clear integration tests:
  * - Clips.getThumb() returns base64 image data for a clip with media
  * - Clips.clear() disconnects a connected clip via REST
+ * - drawThumb() can process a live thumbnail returned by Resolume
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import ArenaRestApi from '../../src/arena-api/rest'
 import { ClipId } from '../../src/domain/clip/clip-id'
 import { TEST_HOST, REST_PORT, TEST_LAYER, TEST_COLUMN } from './config'
 import { isResolumeReachable, pause } from './helpers'
+import { drawThumb } from '../../src/image-utils'
+import { compositionState } from '../../src/state'
 
 const resolume = await isResolumeReachable()
 
@@ -36,6 +39,35 @@ describe.skipIf(!resolume)('REST read — clip thumbnail (requires media)', () =
 		const thumb = await api.Clips.getThumb(new ClipId(TEST_LAYER, TEST_COLUMN))
 		// Base64 uses A–Z a–z 0–9 + / = only
 		expect(/^[A-Za-z0-9+/=]+$/.test(thumb)).toBe(true)
+	})
+})
+
+// ── drawThumb — image-rs pipeline ─────────────────────────────────────────────
+
+describe.skipIf(!resolume)('drawThumb — image-rs pipeline (requires media)', () => {
+	beforeAll(async () => {
+		compositionState.set({ video: { width: { value: 1920 }, height: { value: 1080 } } } as any)
+		await api.Clips.connect(new ClipId(TEST_LAYER, TEST_COLUMN))
+		await pause(400)
+	})
+
+	afterAll(async () => {
+		await api.Layers.clear(TEST_LAYER)
+		compositionState.set(undefined)
+		await pause(300)
+	})
+
+	it('drawThumb returns a Uint8Array from a live Resolume thumbnail', async () => {
+		const thumb = await api.Clips.getThumb(new ClipId(TEST_LAYER, TEST_COLUMN))
+		expect(thumb.length).toBeGreaterThan(0)
+		const result = drawThumb(thumb)
+		expect(result).toBeInstanceOf(Uint8Array)
+	})
+
+	it('drawThumb output is exactly 64×64 RGB (12288 bytes)', async () => {
+		const thumb = await api.Clips.getThumb(new ClipId(TEST_LAYER, TEST_COLUMN))
+		const result = drawThumb(thumb)
+		expect(result.length).toBe(64 * 64 * 3)
 	})
 })
 

--- a/test/unit/image-utils.test.ts
+++ b/test/unit/image-utils.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { drawThumb, drawPercentage, drawVolume } from '../../src/image-utils'
+import { compositionState } from '../../src/state'
+
+// 4×4 grey RGBA PNG encoded as base64
+const TINY_PNG_B64 =
+	'iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAGUlEQVR4AWNsAAIGJMDEgAaYGNAAEwMaAACEVAIIK43mlwAAAABJRU5ErkJggg=='
+
+function makeCompositionState(width = 1920, height = 1080) {
+	return {
+		video: {
+			width: { value: width },
+			height: { value: height },
+		},
+	} as any
+}
+
+beforeEach(() => {
+	compositionState.set(undefined)
+})
+
+describe('drawThumb', () => {
+	it('returns a Uint8Array for a valid base64 PNG', () => {
+		compositionState.set(makeCompositionState())
+		const result = drawThumb(TINY_PNG_B64)
+		expect(result).toBeInstanceOf(Uint8Array)
+	})
+
+	it('output length matches 64×64 RGB (64*64*3 = 12288 bytes)', () => {
+		compositionState.set(makeCompositionState())
+		const result = drawThumb(TINY_PNG_B64)
+		expect(result.length).toBe(64 * 64 * 3)
+	})
+
+	it('handles non-square source aspect ratios without throwing', () => {
+		compositionState.set(makeCompositionState(1920, 1080))
+		expect(() => drawThumb(TINY_PNG_B64)).not.toThrow()
+	})
+
+	it('handles square source aspect ratios without throwing', () => {
+		compositionState.set(makeCompositionState(512, 512))
+		expect(() => drawThumb(TINY_PNG_B64)).not.toThrow()
+	})
+})
+
+describe('drawPercentage', () => {
+	it('returns a Uint8Array', () => {
+		const result = drawPercentage(0.5)
+		expect(result).toBeInstanceOf(Uint8Array)
+	})
+
+	it('does not throw for 0 or 1', () => {
+		expect(() => drawPercentage(0)).not.toThrow()
+		expect(() => drawPercentage(1)).not.toThrow()
+	})
+
+	it('does not throw for values above 1 (overflow path)', () => {
+		expect(() => drawPercentage(1.5)).not.toThrow()
+	})
+})
+
+describe('drawVolume', () => {
+	it('returns a Uint8Array', () => {
+		const result = drawVolume(-6)
+		expect(result).toBeInstanceOf(Uint8Array)
+	})
+
+	it('handles 0 dB without throwing', () => {
+		expect(() => drawVolume(0)).not.toThrow()
+	})
+
+	it('handles large negative values without throwing', () => {
+		expect(() => drawVolume(-60)).not.toThrow()
+	})
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,10 +303,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@julusian/image-rs@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@julusian/image-rs/-/image-rs-0.2.1.tgz#d7ee7ad8ec8b9e5bdfb2cdef8a2647210a0ace7d"
-  integrity sha512-hNToyAoFniHN9AHde93MfA01CGC06bui980/6NWJMky8Zk1kgu4ISEmOYtWOAq5kwmMfdB8mxg2/S3SlKQ9fAA==
+"@julusian/image-rs@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@julusian/image-rs/-/image-rs-1.1.1.tgz#1acfb67a0ed79c67e5635d4133a9dbc25ed87032"
+  integrity sha512-ItgdZbrczYA34shR2HoZ9zD3ZOsdc84Sdxvgh3eb29c3LBEc0NknJpDpPKfdaL7971Ty3OJy3BnMm9GgoQ6ZNA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -2888,6 +2888,7 @@ stream-combiner@~0.0.4:
     duplexer "~0.1.1"
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==


### PR DESCRIPTION
## Summary

- Bumps `@julusian/image-rs` from `^0.2.1` to `^1.1.1`
- The 0.2.x prebuilt required `vcruntime140.dll` on Windows; 1.0.3+ ships a statically-linked binary (reported by @Julusian in #179)
- Adapts `src/image-utils.ts` for the 1.x API: `toBufferSync()` now returns `ComputedImage` instead of `Uint8Array` directly — extracts `.buffer` and wraps in `new Uint8Array()`

## Test plan

- [x] TypeScript build clean
- [x] All 422 unit tests pass (`yarn test`)
- [ ] Windows smoke test: load module in Companion, verify no `ERR_DLOPEN_FAILED` for the native `.node` file

Fixes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)