### PR TITLE
feat: add preset for Disconnect All Clips action (#52)

### DIFF
--- a/src/presets/composition/compositionPresets.ts
+++ b/src/presets/composition/compositionPresets.ts
@@ -1,6 +1,7 @@
 import {CompanionPresetDefinitions} from '@companion-module/base';
 import {tapTempoPreset} from './presets/tapTempoPreset';
 import {resyncTempoPreset} from './presets/resyncTempoPreset';
+import {disconnectAllPreset} from './presets/disconnectAllPreset';
 import {changeTemplateSet100} from '../template/changeLayerGroupMasterSet100';
 import {changeTemplateAdd10} from '../template/changeLayerGroupMasterAdd10';
 import {changeTemplateSubtract10} from '../template/changeLayerGroupMasterSubtract10';
@@ -10,6 +11,7 @@ export function getCompositionApiPresets(category: string): CompanionPresetDefin
 	return {
 		tapTempo: tapTempoPreset(category),
 		resyncTempo: resyncTempoPreset(category),
+		disconnectAll: disconnectAllPreset(category),
 		changeCompositionSpeedSet100: changeTemplateSet100(category,'composition','Speed'),
 		changeCompositionSpeedAdd10: changeTemplateAdd10(category,'composition','Speed'),
 		changeCompositionSpeedSubtract10: changeTemplateSubtract10(category,'composition','Speed'),

--- a/src/presets/composition/presets/disconnectAllPreset.ts
+++ b/src/presets/composition/presets/disconnectAllPreset.ts
@@ -1,0 +1,26 @@
+import {combineRgb} from '@companion-module/base';
+import {CompanionButtonPresetDefinition} from '@companion-module/base/dist/module-api/preset';
+
+export function disconnectAllPreset(category: string): CompanionButtonPresetDefinition {return {
+	type: 'button',
+	category,
+	name: 'Disconnect All Clips',
+	style: {
+		size: '18',
+		text: 'Disconnect All',
+		color: combineRgb(255, 255, 255),
+		bgcolor: combineRgb(0, 0, 0),
+	},
+	steps: [
+		{
+			down: [
+				{
+					actionId: 'disconnectAll',
+					options: {},
+				},
+			],
+			up: [],
+		},
+	],
+	feedbacks: [],
+}}


### PR DESCRIPTION
## Summary

Follow-up to #176 (merged). Adds a Companion preset for the `disconnectAll` action so users can drag it from the preset panel onto a button without manually configuring the action.

- Preset key: `disconnectAll` under the Composition category
- Button label: `Disconnect All`
- Triggers the `disconnectAll` action on press

## Test plan

- [x] `yarn test` — 439 unit tests pass
- [x] Verify preset appears in Companion preset panel under Composition category

🤖 Generated with [Claude Code](https://claude.com/claude-code)