### PR TITLE
fix: clip thumbnails not loaded on module startup

### DIFF
--- a/src/domain/clip/clip-utils.ts
+++ b/src/domain/clip/clip-utils.ts
@@ -193,11 +193,10 @@ export class ClipUtils implements MessageSubscriber {
 					this.clipBase64Thumbs.set(clipId.getIdString(), thumb);
 				}
 			} else {
-				this.resolumeArenaInstance.log('warn', 'thumb is not');
-				return;
+				this.resolumeArenaInstance.log('warn', 'thumb is not available for ' + clipId.getIdString());
 			}
 		}
-		if (thumbPromiseMap.length < 0) {
+		if (thumbPromiseMap.length > 0) {
 			Promise.allSettled(thumbPromiseMap).then(_ => {
 				this.resolumeArenaInstance.checkFeedbacks('clipInfo');
 			});
@@ -459,12 +458,27 @@ export class ClipUtils implements MessageSubscriber {
 		const column = +await context.parseVariablesInString(feedback.options.column as string);
 
 		if (ClipId.isValid(layer, column)) {
-			const idString = new ClipId(layer, column).getIdString();
-			if (!this.clipDetailsSubscriptions.get(idString)) {
+			const clipId = new ClipId(layer, column);
+			const idString = clipId.getIdString();
+			const isNewClip = !this.clipDetailsSubscriptions.get(idString);
+			if (isNewClip) {
 				this.clipDetailsSubscriptions.set(idString, new Set());
 				this.clipDetailsWebsocketSubscribe(layer, column);
 			}
 			this.clipDetailsSubscriptions.get(idString)?.add(feedback.id);
+
+			// Composition already loaded before this subscription arrived — fetch the thumb now.
+			if (isNewClip && this.initalLoadDone) {
+				const thumb = await this.resolumeArenaInstance.restApi?.Clips.getThumb(clipId);
+				if (thumb) {
+					if (this.resolumeArenaInstance.getConfig().useCroppedThumbs) {
+						await this.getThumbs(clipId, feedback.id);
+					} else {
+						this.clipBase64Thumbs.set(idString, thumb);
+						this.resolumeArenaInstance.checkFeedbacks('clipInfo');
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- **Root cause**: race condition between the WebSocket receiving the initial composition and Companion calling each feedback's `subscribe` callback. When the composition arrives first, `initDetailsFromComposition` iterates an empty `clipDetailsSubscriptions` map and skips all thumbnail fetches. Subsequent composition updates (e.g. deck switch) arrive after subscriptions are registered, which is why thumbs appeared then but not on cold start.
- **Fix**: in `clipDetailsFeedbackSubscribe`, when `initalLoadDone` is already `true` and we are registering a clip for the first time, fetch the thumbnail immediately.
- **Bonus fixes** in `initDetailsFromComposition`:
  - `return` on a failed thumb now logs-and-continues instead of aborting the entire loop
  - `thumbPromiseMap.length < 0` corrected to `> 0` so `checkFeedbacks('clipInfo')` is actually called after all cropped thumbs resolve

## Test plan

- [ ] Load a Companion page with `clipInfo` feedbacks configured
- [ ] Start the module — thumbnails should appear immediately without needing to switch decks
- [ ] Switch decks — thumbnails should still update correctly
- [ ] `yarn test` passes (533 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)