### PR TITLE
feat: add Update Clip Thumbnail action

### DIFF
--- a/src/actions/clip/actions/update-clip-thumbnail.ts
+++ b/src/actions/clip/actions/update-clip-thumbnail.ts
@@ -1,0 +1,45 @@
+import {CompanionActionDefinition} from '@companion-module/base';
+import ArenaRestApi from '../../../arena-api/rest';
+import {ClipId} from '../../../domain/clip/clip-id';
+import {ClipUtils} from '../../../domain/clip/clip-utils';
+import {ResolumeArenaModuleInstance} from '../../../index';
+import {getClipOption} from '../../../defaults';
+
+export function updateClipThumbnail(
+	restApi: () => ArenaRestApi | null,
+	clipUtils: () => ClipUtils | null,
+	resolumeArenaModuleInstance: ResolumeArenaModuleInstance
+): CompanionActionDefinition {
+	return {
+		name: 'Update Clip Thumbnail',
+		options: [
+			{
+				id: 'target',
+				type: 'dropdown',
+				label: 'Target',
+				choices: [
+					{id: 'layerColumn', label: 'Layer / Column'},
+					{id: 'selected', label: 'Selected clip'},
+				],
+				default: 'layerColumn',
+			},
+			...getClipOption().map((opt) => ({...opt, isVisible: (options: any) => options.target === 'layerColumn'})),
+		],
+		callback: async ({options}: {options: any}): Promise<void> => {
+			const rest = restApi();
+			if (!rest) return;
+
+			if (options.target === 'selected') {
+				await rest.Clips.updateSelectedThumb();
+			} else {
+				const layer = +await resolumeArenaModuleInstance.parseVariablesInString(options.layer);
+				const column = +await resolumeArenaModuleInstance.parseVariablesInString(options.column);
+				await rest.Clips.updateThumb(new ClipId(layer, column));
+			}
+
+			setTimeout(() => {
+				clipUtils()?.initDetailsFromComposition();
+			}, 1000);
+		},
+	};
+}

--- a/src/actions/clip/clipActions.ts
+++ b/src/actions/clip/clipActions.ts
@@ -5,6 +5,7 @@ import {connectClip} from './actions/connect-clip';
 import {clipSpeedChange} from './actions/clip-speed-change';
 import {clipOpacityChange} from './actions/clip-opacity-change';
 import {clipVolumeChange} from './actions/clip-volume-change';
+import {updateClipThumbnail} from './actions/update-clip-thumbnail';
 
 export function getClipActions(resolumeArenaModuleInstance: ResolumeArenaModuleInstance): CompanionActionDefinitions {
 	const restApi = resolumeArenaModuleInstance.getRestApi.bind(resolumeArenaModuleInstance);
@@ -17,5 +18,6 @@ export function getClipActions(resolumeArenaModuleInstance: ResolumeArenaModuleI
 		clipSpeedChange: clipSpeedChange(restApi, websocketApi, oscApi, clipUtils, resolumeArenaModuleInstance),
 		clipOpacityChange: clipOpacityChange(restApi, websocketApi, oscApi, clipUtils, resolumeArenaModuleInstance),
 		clipVolumeChange: clipVolumeChange(restApi, websocketApi, oscApi, clipUtils, resolumeArenaModuleInstance),
+		updateClipThumbnail: updateClipThumbnail(restApi, clipUtils, resolumeArenaModuleInstance),
 	};
 }

--- a/src/arena-api/child-apis/ArenaClipsApi.ts
+++ b/src/arena-api/child-apis/ArenaClipsApi.ts
@@ -41,4 +41,13 @@ export class ArenaClipsApi {
 		var fileUri = `file:///${filename}`;
 		await this.arenaFetch('post', url, 'bool', fileUri);
 	}
+
+	async updateThumb(clipId: ClipId) {
+		var url = `composition/layers/${clipId.getLayer()}/clips/${clipId.getColumn()}/thumbnail/update`;
+		await this.arenaFetch('post', url, 'ok');
+	}
+
+	async updateSelectedThumb() {
+		await this.arenaFetch('post', 'composition/clips/selected/thumbnail/update', 'ok');
+	}
 }

--- a/src/domain/clip/clip-utils.ts
+++ b/src/domain/clip/clip-utils.ts
@@ -196,12 +196,11 @@ export class ClipUtils implements MessageSubscriber {
 				this.resolumeArenaInstance.log('warn', 'thumb is not available for ' + clipId.getIdString());
 			}
 		}
-		if (thumbPromiseMap.length > 0) {
-			Promise.allSettled(thumbPromiseMap).then(_ => {
-				this.resolumeArenaInstance.checkFeedbacks('clipInfo');
-			});
-		}
-
+		// Always checkFeedbacks after all thumbs resolve — the non-cropped path
+		// updates clipBase64Thumbs but never triggered a re-evaluation without this.
+		Promise.allSettled(thumbPromiseMap).then(_ => {
+			this.resolumeArenaInstance.checkFeedbacks('clipInfo');
+		});
 	}
 
 	async getThumbs(clipId: ClipId, feedbackId: string) {

--- a/src/presets/clip/clipPresets.ts
+++ b/src/presets/clip/clipPresets.ts
@@ -1,6 +1,7 @@
 import {CompanionPresetDefinitions} from '@companion-module/base';
 import {triggerClipPreset} from './presets/triggerClipPreset';
 import {selectClipPreset} from './presets/selectClipPreset';
+import {updateClipThumbnailPreset} from './presets/updateClipThumbnailPreset';
 import {changeTemplateSet100} from '../template/changeLayerGroupMasterSet100';
 import {changeTemplateAdd10} from '../template/changeLayerGroupMasterAdd10';
 import {changeTemplateSubtract10} from '../template/changeLayerGroupMasterSubtract10';
@@ -11,6 +12,7 @@ export function getClipApiPresets(category: string): CompanionPresetDefinitions 
 	return {
 		triggerClip: triggerClipPreset(category),
 		selectClip: selectClipPreset(category),
+		updateClipThumbnail: updateClipThumbnailPreset(category),
 		changeClipSpeedSet100: changeTemplateSet100(category, 'clip', 'Speed', false, getDefaultLayerColumnOptions()),
 		changeClipSpeedAdd10: changeTemplateAdd10(category, 'clip', 'Speed', false, getDefaultLayerColumnOptions()),
 		changeClipSpeedSubtract10: changeTemplateSubtract10(category, 'clip', 'Speed', false, getDefaultLayerColumnOptions()),

--- a/src/presets/clip/presets/updateClipThumbnailPreset.ts
+++ b/src/presets/clip/presets/updateClipThumbnailPreset.ts
@@ -1,0 +1,32 @@
+import {combineRgb} from '@companion-module/base';
+import {CompanionButtonPresetDefinition} from '@companion-module/base/dist/module-api/preset';
+import {getDefaultLayerColumnOptions} from '../../../defaults';
+
+export function updateClipThumbnailPreset(category: string): CompanionButtonPresetDefinition {
+	return {
+		type: 'button',
+		category,
+		name: 'Update Clip Thumbnail',
+		style: {
+			size: '14',
+			text: 'Update Thumb',
+			color: combineRgb(255, 255, 255),
+			bgcolor: combineRgb(0, 80, 160),
+		},
+		steps: [
+			{
+				down: [
+					{
+						actionId: 'updateClipThumbnail',
+						options: {
+							target: 'layerColumn',
+							...getDefaultLayerColumnOptions(),
+						},
+					},
+				],
+				up: [],
+			},
+		],
+		feedbacks: [],
+	};
+}

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -103,19 +103,6 @@ export class WebsocketInstance {
 					for (const subscriber of this.resolumeArenaInstance.getWebSocketSubscribers()) {
 						subscriber.effectsUpdated?.();
 					}
-				} else if (message.type === 'thumbnail_update') {
-					// setComposition((composition: any) => {
-					// 	for (const layer of composition.layers) {
-					// 		for (const clip of layer.clips) {
-					// 			if (clip.id === message.value.id) {
-					// 				clip.thumbnail = message.value;
-					// 				return {...composition};
-					// 			}
-					// 		}
-					// 	}
-					// 	// no match found, re-use existing composition
-					// 	return composition;
-					// });
 				} else if (message.type === 'parameter_update' || message.type === 'parameter_subscribed') {
 					const parameter = message as {path: string; value: string | boolean | number};
 					if (!message.path.includes('/transport/position')) {

--- a/test/unit/clip-column-actions.test.ts
+++ b/test/unit/clip-column-actions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { connectClip } from '../../src/actions/clip/actions/connect-clip'
 import { selectClip } from '../../src/actions/clip/actions/select-clip'
+import { updateClipThumbnail } from '../../src/actions/clip/actions/update-clip-thumbnail'
 import { connectColumn } from '../../src/actions/column/actions/connectColumn'
 import { selectColumn } from '../../src/actions/column/actions/selectColumn'
 import { selectDeck } from '../../src/actions/deck/actions/select-deck'
@@ -60,6 +61,37 @@ describe('selectClip', () => {
 		await (action.callback as any)({ options: { layer: '1', column: '3' } })
 		expect(ws.triggerPath).toHaveBeenCalledWith('/composition/layers/1/clips/3/select', true)
 		expect(ws.triggerPath).toHaveBeenCalledWith('/composition/layers/1/clips/3/select', false)
+	})
+})
+
+// ── updateClipThumbnail ────────────────────────────────────────────────────────
+
+describe('updateClipThumbnail — layer/column target', () => {
+	it('calls rest.Clips.updateThumb with the correct ClipId', async () => {
+		const updateThumb = vi.fn().mockResolvedValue(undefined)
+		const restApi = { Clips: { updateThumb, updateSelectedThumb: vi.fn() } }
+		const instance = makeInstance('2', '4')
+		const action = updateClipThumbnail(() => restApi as any, () => null, instance)
+		await (action.callback as any)({ options: { target: 'layerColumn', layer: '2', column: '4' } })
+		expect(updateThumb).toHaveBeenCalledOnce()
+		const clipId = updateThumb.mock.calls[0][0]
+		expect(clipId.getLayer()).toBe(2)
+		expect(clipId.getColumn()).toBe(4)
+	})
+
+	it('does nothing when restApi is null', async () => {
+		const action = updateClipThumbnail(() => null, () => null, makeInstance())
+		await expect((action.callback as any)({ options: { target: 'layerColumn', layer: '1', column: '1' } })).resolves.toBeUndefined()
+	})
+})
+
+describe('updateClipThumbnail — selected target', () => {
+	it('calls rest.Clips.updateSelectedThumb', async () => {
+		const updateSelectedThumb = vi.fn().mockResolvedValue(undefined)
+		const restApi = { Clips: { updateThumb: vi.fn(), updateSelectedThumb } }
+		const action = updateClipThumbnail(() => restApi as any, () => null, makeInstance())
+		await (action.callback as any)({ options: { target: 'selected' } })
+		expect(updateSelectedThumb).toHaveBeenCalledOnce()
 	})
 })
 


### PR DESCRIPTION
## Summary

- Adds a new **Update Clip Thumbnail** action, available in Resolume 7.25+ via `POST /thumbnail/update` endpoints. Supports targeting a specific layer/column (with layer/column fields hidden when not applicable) or the currently selected clip.
- After the Resolume REST call, `initDetailsFromComposition()` is scheduled after 1 s to re-fetch all active thumbnails and push updated images into Companion buttons.
- Fixes a pre-existing bug in `initDetailsFromComposition()`: the non-cropped-thumb path updated `clipBase64Thumbs` but never called `checkFeedbacks('clipInfo')`, causing buttons to stay stale after any composition reload.
- Removes dead React-style commented-out code from the `thumbnail_update` WebSocket handler.
- Includes a preset and unit tests.

Closes #141

## Test plan

- [ ] Trigger the action targeting a specific layer/column — Resolume thumbnail updates; ~1 s later the Companion button reflects the new image
- [ ] Trigger the action with **Selected clip** target — same result for whichever clip is currently selected
- [ ] Reload the module with clips that have media — verify all thumbnails load on startup without needing a deck change (regression fix)
- [ ] Unit tests pass: `yarn test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)